### PR TITLE
Stop early close message from being sent

### DIFF
--- a/packages/importer/package.json
+++ b/packages/importer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@oneschema/importer",
   "private": false,
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Importer for using OneSchema",
   "author": "OneSchema",
   "license": "MIT",

--- a/packages/importer/src/index.ts
+++ b/packages/importer/src/index.ts
@@ -155,7 +155,10 @@ class OneSchemaImporter extends EventEmitter {
   }
 
   close(clean?: boolean) {
-    this.iframe.contentWindow?.postMessage({ messageType: "close" }, this.#baseUrl)
+    if (this.#isLoaded) {
+      this.iframe.contentWindow?.postMessage({ messageType: "close" }, this.#baseUrl)
+    }
+
     this.#hide()
 
     if (clean) {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@oneschema/react",
   "private": false,
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "React component for using OneSchema",
   "author": "OneSchema",
   "license": "MIT",
@@ -32,7 +32,7 @@
     "clean": "npx rimraf dist"
   },
   "dependencies": {
-    "@oneschema/importer": "^0.1.5"
+    "@oneschema/importer": "^0.1.6"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^22.0.0",


### PR DESCRIPTION
Currently, it's possible to try and 'close' the iframe before it is loaded. Adding a check that will stop that.