### PR TITLE
Update constructor/config of base importer

### DIFF
--- a/packages/importer/package.json
+++ b/packages/importer/package.json
@@ -32,12 +32,14 @@
     "clean": "npx rimraf dist"
   },
   "dependencies": {
-    "eventemitter3": "^4.0.7"
+    "eventemitter3": "^4.0.7",
+    "lodash.merge": "^4.6.2"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^22.0.0",
     "@rollup/plugin-node-resolve": "^13.3.0",
     "@rollup/plugin-replace": "^4.0.0",
+    "@types/lodash.merge": "^4.6.7",
     "@typescript-eslint/eslint-plugin": "^5.30.0",
     "@typescript-eslint/parser": "^5.30.0",
     "eslint": "^8.18.0",

--- a/packages/importer/src/config.ts
+++ b/packages/importer/src/config.ts
@@ -1,7 +1,7 @@
 /**
  * Config options for how the OneSchema importer will behave
  */
-export interface OneSchemaEmbedConfig {
+export interface OneSchemaConfig {
   /**
    * Whether importing should be blocked if there are validation errors in the data
    */
@@ -13,9 +13,9 @@ export interface OneSchemaEmbedConfig {
 }
 
 /**
- * Config options that can be set when the OneSchema importer launches
+ * Parameters that can be set when the OneSchema importer launches
  */
-export interface OneSchemaLaunchConfig {
+export interface OneSchemaLaunchParams {
   /**
    * The JSON web token for the user importing data
    */
@@ -33,13 +33,13 @@ export interface OneSchemaLaunchConfig {
   /**
    * Config options for how the OneSchema importer will behave
    */
-  config?: OneSchemaEmbedConfig
+  config?: OneSchemaConfig
 }
 
 /**
- * Base config for the OneSchema importer, includes all settings
+ * Parameters for the OneSchema importer, includes all settings
  */
-export interface OneSchemaConfig extends Partial<OneSchemaLaunchConfig> {
+export interface OneSchemaParams extends Partial<OneSchemaLaunchParams> {
   /**
    * The client id from your OneSchema developer dashboard
    */
@@ -73,7 +73,8 @@ export interface OneSchemaConfig extends Partial<OneSchemaLaunchConfig> {
 /**
  * The default values for the OneSchema importer
  */
-export const DEFAULT_CONFIG: Partial<OneSchemaConfig> = {
+export const DEFAULT_PARAMS: Partial<OneSchemaParams> = {
+  baseUrl: "https://embed.oneschema.co",
   devMode: !!(process.env.NODE_ENV !== "production"),
   className: "oneschema-iframe",
   autoClose: true,

--- a/packages/importer/src/config.ts
+++ b/packages/importer/src/config.ts
@@ -1,0 +1,83 @@
+/**
+ * Config options for how the OneSchema importer will behave
+ */
+export interface OneSchemaEmbedConfig {
+  /**
+   * Whether importing should be blocked if there are validation errors in the data
+   */
+  blockImportIfErrors?: boolean
+  /**
+   * Whether fixable errors should automatically be fixed after the mapping headers step
+   */
+  autofixAfterMapping?: boolean
+}
+
+/**
+ * Config options that can be set when the OneSchema importer launches
+ */
+export interface OneSchemaLaunchConfig {
+  /**
+   * The JSON web token for the user importing data
+   */
+  userJwt: string
+  /**
+   * The key for the template that data will be imported for.
+   * Setup inside OneSchema before using
+   */
+  templateKey: string
+  /**
+   * The key for the webhook that data from this import
+   * should be sent to. Setup inside Oneschema before using
+   */
+  webhookKey?: string
+  /**
+   * Config options for how the OneSchema importer will behave
+   */
+  config?: OneSchemaEmbedConfig
+}
+
+/**
+ * Base config for the OneSchema importer, includes all settings
+ */
+export interface OneSchemaConfig extends Partial<OneSchemaLaunchConfig> {
+  /**
+   * The client id from your OneSchema developer dashboard
+   */
+  clientId: string
+  /**
+   * Whether to launch the importer in dev mode.
+   * By default checks `process.env.NODE_ENV` for "production"
+   */
+  devMode?: boolean
+  /**
+   * CSS class for the iframe
+   */
+  className?: string
+  /**
+   * The id of the DOM element the iframe should be appended to
+   * By default appends to document.body
+   */
+  parentId?: string
+  /**
+   * Whether to close the importer when complete.
+   * Defaults to true
+   */
+  autoClose?: boolean
+  /**
+   * The base URL for the iframe.
+   * By default uses OneSchema's production instance
+   */
+  baseUrl?: string
+}
+
+/**
+ * The default values for the OneSchema importer
+ */
+export const DEFAULT_CONFIG: Partial<OneSchemaConfig> = {
+  devMode: !!(process.env.NODE_ENV !== "production"),
+  className: "oneschema-iframe",
+  autoClose: true,
+  config: {
+    blockImportIfErrors: true,
+  },
+}

--- a/packages/importer/src/index.ts
+++ b/packages/importer/src/index.ts
@@ -1,39 +1,15 @@
 import { EventEmitter } from "eventemitter3"
+import merge from "lodash.merge"
+import { OneSchemaConfig, DEFAULT_CONFIG, OneSchemaLaunchConfig } from "./config"
 
-export interface OneSchemaImporterConfigOptions {
-  enableManageColumns?: boolean
-  autofixAfterMapping?: boolean
-  blockImportIfErrors?: boolean
-}
-
-export interface OneSchemaImporterConfig {
-  userJwt: string
-  templateKey: string
-  webhookKey?: string
-  options?: OneSchemaImporterConfigOptions
-}
-
-export interface OneSchemaIframeConfig {
-  devMode?: boolean
-  className?: string
-  parentId?: string
-  autoClose?: boolean
-}
-
-const DEFAULT_IFRAME_CONFIG: OneSchemaIframeConfig = {
-  devMode: !!(process.env.NODE_ENV !== "production"),
-  className: "oneschema-iframe",
-  autoClose: true,
-}
-
-const DEFAULT_ONESCHEMA_OPTIONS: OneSchemaImporterConfigOptions = {
-  blockImportIfErrors: true,
-}
-
+/**
+ * OneSchemaImporter class manages the iframe
+ * used for importing data in your application
+ * and emits events based on what happens
+ */
 class OneSchemaImporter extends EventEmitter {
-  clientId: string
+  #config: OneSchemaConfig
   iframe?: HTMLIFrameElement
-  iframeConfig: OneSchemaIframeConfig
   #baseUrl = "https://embed.oneschema.co"
   #eventListener: (event: MessageEvent) => void = () => null
   static #isLoaded = false
@@ -51,8 +27,8 @@ class OneSchemaImporter extends EventEmitter {
   }
 
   #getParent(): HTMLElement {
-    if (this.iframeConfig.parentId) {
-      const parent = document.getElementById(this.iframeConfig.parentId)
+    if (this.#config.parentId) {
+      const parent = document.getElementById(this.#config.parentId)
       if (parent) {
         return parent
       }
@@ -61,17 +37,13 @@ class OneSchemaImporter extends EventEmitter {
     return document.body
   }
 
-  constructor(clientId: string, iframeConfig?: OneSchemaIframeConfig, baseUrl?: string) {
+  constructor(config: OneSchemaConfig) {
     super()
 
-    this.clientId = clientId
-    this.iframeConfig = {
-      ...DEFAULT_IFRAME_CONFIG,
-      ...(iframeConfig || {}),
-    }
+    this.#config = merge({}, DEFAULT_CONFIG, config)
 
-    if (baseUrl) {
-      this.#baseUrl = baseUrl
+    if (config.baseUrl) {
+      this.#baseUrl = config.baseUrl
     }
 
     if (typeof window === "undefined") {
@@ -86,9 +58,11 @@ class OneSchemaImporter extends EventEmitter {
       this.iframe.id = iframeId
       this.iframe.dataset.count = "1"
 
-      const queryParams = `?embed_client_id=${this.clientId}&dev_mode=${this.iframeConfig.devMode}`
+      const queryParams = `?embed_client_id=${this.#config.clientId}&dev_mode=${
+        this.#config.devMode
+      }`
       this.iframe.src = `${this.#baseUrl}/embed-launcher${queryParams}`
-      this.iframe.className = this.iframeConfig.className || ""
+      this.iframe.className = this.#config.className || ""
       OneSchemaImporter.#isLoaded = false
       this.iframe.onload = () => {
         OneSchemaImporter.#isLoaded = true
@@ -107,7 +81,7 @@ class OneSchemaImporter extends EventEmitter {
       switch (event.data.messageType) {
         case "complete": {
           this.emit("success", event.data.data)
-          if (this.iframeConfig.autoClose) {
+          if (this.#config.autoClose) {
             this.close()
           }
 
@@ -115,7 +89,7 @@ class OneSchemaImporter extends EventEmitter {
         }
         case "cancel": {
           this.emit("cancel")
-          if (this.iframeConfig.autoClose) {
+          if (this.#config.autoClose) {
             this.close()
           }
 
@@ -123,7 +97,7 @@ class OneSchemaImporter extends EventEmitter {
         }
         case "error": {
           this.emit("error", event.data.message)
-          if (this.iframeConfig.autoClose) {
+          if (this.#config.autoClose) {
             this.close()
           }
           break
@@ -135,23 +109,36 @@ class OneSchemaImporter extends EventEmitter {
     parent.append(this.iframe)
   }
 
-  launch(config: OneSchemaImporterConfig) {
+  /**
+   * Launch will show the OneSchema window and initialize the importer session
+   * @param launchConfig optionally pass in config overrides or values not passed into constructor
+   */
+  launch(launchConfig?: Partial<OneSchemaLaunchConfig>) {
     window.addEventListener("message", this.#eventListener)
     this.#show()
 
-    const { options, ...rest } = config
+    const mergedConfig = merge({}, this.#config, launchConfig)
+    const message: any = { messageType: "init" }
+    message.options = mergedConfig.config
+
+    message.userJwt = mergedConfig.userJwt
+    if (!message.userJwt) {
+      console.error("OneSchema config error: missing userJwt")
+      return
+    }
+
+    message.templateKey = mergedConfig.templateKey
+    if (!message.templateKey) {
+      console.error("OneSchema config error: missing templateKey")
+      return
+    }
+
+    if (mergedConfig.webhookKey) {
+      message.webhookKey = mergedConfig.webhookKey
+    }
+
     const postInit = () => {
-      this.iframe?.contentWindow?.postMessage(
-        {
-          messageType: "init",
-          ...rest,
-          options: {
-            ...DEFAULT_ONESCHEMA_OPTIONS,
-            ...options,
-          },
-        },
-        this.#baseUrl,
-      )
+      this.iframe?.contentWindow?.postMessage(message, this.#baseUrl)
     }
 
     if (OneSchemaImporter.#isLoaded) {
@@ -162,6 +149,10 @@ class OneSchemaImporter extends EventEmitter {
     }
   }
 
+  /**
+   * Close will stop the importing session and hide the OneSchema window
+   * @param clean will remove the iframe and event listeners if true
+   */
   close(clean?: boolean) {
     if (this.iframe && OneSchemaImporter.#isLoaded) {
       this.iframe.contentWindow?.postMessage({ messageType: "close" }, this.#baseUrl)
@@ -183,10 +174,10 @@ class OneSchemaImporter extends EventEmitter {
 
 export type OneSchemaImporterClass = InstanceType<typeof OneSchemaImporter>
 
-export default function oneSchemaImporter(
-  clientId: string,
-  iframeConfig?: OneSchemaIframeConfig,
-  baseUrl?: string,
-): OneSchemaImporter {
-  return new OneSchemaImporter(clientId, iframeConfig, baseUrl)
+/**
+ * @param config the settings for the importing session
+ * @returns an instance of the OneSchemaImporter
+ */
+export default function oneSchemaImporter(config: OneSchemaConfig): OneSchemaImporter {
+  return new OneSchemaImporter(config)
 }

--- a/packages/importer/test/index.ts
+++ b/packages/importer/test/index.ts
@@ -1,25 +1,21 @@
 import oneSchemaImporter from "../src"
 
-const importer = oneSchemaImporter(
-  "67bb2e5f-f0f7-42a6-a511-18b25e67b8c4",
-  {
-    className: "oneschema-iframe",
-    parentId: "oneschema-container",
+const importer = oneSchemaImporter({
+  clientId: "67bb2e5f-f0f7-42a6-a511-18b25e67b8c4",
+  className: "oneschema-iframe",
+  parentId: "oneschema-container",
+  baseUrl: "http://embed.localschema.co:9450",
+  templateKey: "crm_test",
+  userJwt:
+    "eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiI2N2JiMmU1Zi1mMGY3LTQyYTYtYTUxMS0xOGIyNWU2N2I4YzQiLCJ1c2VyX2lkIjoxMjM0fQ.MaxfODdhWqVamNgK7l8mZrR-A4B2uGDuPWLOreu7dQI",
+  config: {
+    autofixAfterMapping: true,
+    blockImportIfErrors: true,
   },
-  "http://embed.localschema.co:9450",
-)
+})
 
 function start() {
-  importer.launch({
-    templateKey: "crm_test",
-    userJwt:
-      "eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiI2N2JiMmU1Zi1mMGY3LTQyYTYtYTUxMS0xOGIyNWU2N2I4YzQiLCJ1c2VyX2lkIjoxMjM0fQ.MaxfODdhWqVamNgK7l8mZrR-A4B2uGDuPWLOreu7dQI",
-    options: {
-      enableManageColumns: true,
-      autofixAfterMapping: true,
-      blockImportIfErrors: true,
-    },
-  })
+  importer.launch()
 }
 
 importer.on("success", (data) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -902,6 +902,18 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==
 
+"@types/lodash.merge@^4.6.7":
+  version "4.6.7"
+  resolved "https://registry.yarnpkg.com/@types/lodash.merge/-/lodash.merge-4.6.7.tgz#0af6555dd8bc6568ef73e5e0d820a027362946b1"
+  integrity sha512-OwxUJ9E50gw3LnAefSHJPHaBLGEKmQBQ7CZe/xflHkyy/wH2zVyEIAKReHvVrrn7zKdF58p16We9kMfh7v0RRQ==
+  dependencies:
+    "@types/lodash" "*"
+
+"@types/lodash@*":
+  version "4.14.182"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.182.tgz#05301a4d5e62963227eaafe0ce04dd77c54ea5c2"
+  integrity sha512-/THyiqyQAP9AfARo4pF+aCGcyiQ94tX/Is2I7HofNRqoYLgN1PBoOWu2/zTA5zMxzP5EFutMtWtGAFRKUe961Q==
+
 "@types/node@*":
   version "18.0.0"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.0.0.tgz#67c7b724e1bcdd7a8821ce0d5ee184d3b4dd525a"


### PR DESCRIPTION
Please pay special attention to naming and comments. In base changes setup from:

```
const importer = oneschemaImporter(clientId, {
  className: "my-iframe-class",
  parentId: "my-iframe-container",
  autoClose: true,
})

importer.launch({
  templateKey: "test_template",
  userJwt: token,
  options: {
    blockImportIfErrors: true,
  },
})
```

to:

```
const importer = oneSchemaImporter({
  clientId,
  className: "my-iframe-class",
  parentId: "my-iframe-container",
  templateKey: "test_template",
  userJwt: token,
  config: {
    blockImportIfErrors: true,
  },
})

importer.launch()
```