### PR TITLE
Update React for new API

### DIFF
--- a/packages/react/src/OneSchemaImporter.tsx
+++ b/packages/react/src/OneSchemaImporter.tsx
@@ -23,11 +23,11 @@ export interface OneSchemaImporterProps {
   webhookKey?: string
   config?: OneSchemaConfig
   /**
-   * DEPRACATED: use config prop instead
+   * DEPRECATED: use config prop instead
    */
   blockImportIfErrors?: boolean
   /**
-   * DEPRACATED: use inline prop instead
+   * DEPRECATED: use inline prop instead
    */
   parentId?: string
   /**

--- a/packages/react/src/OneSchemaImporter.tsx
+++ b/packages/react/src/OneSchemaImporter.tsx
@@ -1,45 +1,94 @@
-import { useEffect, useState } from "react"
-import oneschemaImporter, {
-  OneSchemaIframeConfig,
-  OneSchemaImporterConfig,
-  OneSchemaImporterConfigOptions,
-} from "@oneschema/importer"
+import React, { useCallback, useEffect, useRef, useState } from "react"
+import oneschemaImporter, { OneSchemaConfig } from "@oneschema/importer"
 
 export interface OneSchemaImporterProps {
+  /**
+   * Whether to show the iframe or not
+   */
   isOpen: boolean
-
+  /**
+   * Whether the iframe should be rendered in the component tree
+   * If false or not set, the iframe will append to document.body
+   */
+  inline?: boolean
+  /**
+   * These props are passed directly into the OneSchemaImporter as params
+   */
   clientId: string
+  className?: string
+  devMode?: boolean
+  baseUrl?: string
   userJwt: string
   templateKey: string
   webhookKey?: string
-
+  config?: OneSchemaConfig
+  /**
+   * DEPRACATED: use config prop instead
+   */
   blockImportIfErrors?: boolean
-
-  className?: string
+  /**
+   * DEPRACATED: use inline prop instead
+   */
   parentId?: string
-  devMode?: boolean
-
+  /**
+   * CSS styles that should be applied to the iframe
+   */
   style?: React.CSSProperties
-
+  /**
+   * Handler for when the importer wants to close
+   * should set isOpen prop to false
+   */
   onRequestClose?: () => void
+  /**
+   * Handler for when the importing flow completes successfully
+   */
   onSuccess?: (data: any) => void
+  /**
+   * Handler for when the importing flow is cancelled by user
+   */
   onCancel?: () => void
+  /**
+   * Handler for when an error occurs during the import
+   */
   onError?: (message: string) => void
-
-  baseUrl?: string
 }
 
-export default function OneSchemaImporter(props: OneSchemaImporterProps) {
-  const [importer] = useState(() => {
-    const { parentId, className, devMode } = props
-    const importerOptions: OneSchemaIframeConfig = Object.assign(
-      { autoClose: false },
-      parentId !== undefined && { parentId },
-      className !== undefined && { className },
-      devMode !== undefined && { devMode },
-    )
+/**
+ * Component for importing data with OneSchema
+ */
+export default function OneSchemaImporter({
+  isOpen,
+  style,
+  inline,
+  onRequestClose,
+  onSuccess,
+  onCancel,
+  onError,
 
-    return oneschemaImporter(props.clientId, importerOptions, props.baseUrl)
+  // deprecated
+  blockImportIfErrors,
+  parentId,
+
+  ...params
+}: OneSchemaImporterProps) {
+  if (blockImportIfErrors !== undefined) {
+    console.warn(
+      "OneSchema prop 'blockImportIfErrors' is deprecated. Use 'config' prop instead",
+    )
+  }
+
+  if (parentId !== undefined) {
+    console.warn(
+      "OneSchema prop 'parentId' is deprecated. Use 'inline' prop, possibly with portal instead",
+    )
+  }
+
+  const [importer] = useState(() => {
+    return oneschemaImporter({
+      ...params,
+      autoClose: false,
+      manageDOM: inline,
+    })
   })
 
   useEffect(() => {
@@ -48,7 +97,6 @@ export default function OneSchemaImporter(props: OneSchemaImporterProps) {
     }
   }, [importer])
 
-  const { onSuccess, onCancel, onError, onRequestClose } = props
   useEffect(() => {
     if (importer) {
       importer.on("success", (data) => {
@@ -73,53 +121,56 @@ export default function OneSchemaImporter(props: OneSchemaImporterProps) {
   }, [importer, onSuccess, onCancel, onError, onRequestClose])
 
   useEffect(() => {
-    if (props.className && importer) {
-      importer.iframe.className = props.className
+    if (params.className && importer) {
+      importer.setClassName(params.className)
     }
-  }, [importer, props.className])
+  }, [importer, params.className])
 
   useEffect(() => {
-    if (props.style && importer) {
-      Object.entries(props.style).forEach(([key, value]) => {
-        importer.iframe.style.setProperty(key, value)
+    if (style && importer && importer.iframe) {
+      Object.entries(style).forEach(([key, value]) => {
+        importer.iframe!.style.setProperty(key, value)
       })
     }
 
     return () => {
-      if (props.style && importer) {
-        Object.keys(props.style).forEach((key) => {
-          importer.iframe.style.removeProperty(key)
+      if (style && importer && importer.iframe) {
+        Object.keys(style).forEach((key) => {
+          importer.iframe!.style.removeProperty(key)
         })
       }
     }
-  }, [importer, props.style])
+  }, [importer, style])
 
   useEffect(() => {
     if (importer) {
-      if (props.isOpen) {
-        const { webhookKey, blockImportIfErrors } = props
-
-        const options: OneSchemaImporterConfigOptions = Object.assign(
-          {},
-          blockImportIfErrors !== undefined ? { blockImportIfErrors } : {},
-        )
-
-        const launchConfig: OneSchemaImporterConfig = Object.assign(
-          {
-            userJwt: props.userJwt,
-            templateKey: props.templateKey,
-            options,
-          },
-          webhookKey !== undefined && { webhookKey },
-        )
-
-        importer.launch(launchConfig)
+      if (isOpen) {
+        importer.launch(params)
       } else {
         importer.close()
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [importer, props.isOpen])
+  }, [importer, isOpen])
 
-  return null
+  const iframeRef = useRef<HTMLIFrameElement>()
+  const setIframeRef = useCallback((iframe: HTMLIFrameElement) => {
+    if (iframe && importer) {
+      importer.setIframe(iframe)
+    }
+
+    iframeRef.current = iframe
+  }, [])
+
+  if (inline) {
+    return <Iframe ref={setIframeRef} />
+  } else {
+    return null
+  }
 }
+
+const Iframe = React.memo(
+  React.forwardRef<HTMLIFrameElement>((_, ref) => {
+    return <iframe ref={ref} />
+  }),
+)


### PR DESCRIPTION
- changes props and usage patterns to match updates in the importer
- adds a memo'd iframe to possibly be rendered inline
- deprecates 'blockImportIfErrors' and 'parentId'
  - we could still use these values, but as it stands, they will produce warning and not be used