### PR TITLE
Update config to customizationOverride and importConfig (0.3.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ This log is intended to keep track of package changes, including
 but not limited to API changes and file location changes. Minor behavioral
 changes may not be included if they are not expected to break existing code.
 
+## 0.3.0 (2022-11-15)
+
+* Updates to how config is specified with some breaking changes:
+  * Add `customizationOverrides` and `importConfig` to params
+  * Remove `config` and `webhookKey` from params. To migrate:
+    * For most `config` values, pass them into `customizationOverride` or set on the [Customizations page](https://app.oneschema.co/customizations).
+    * For `skipExportData` set `importConfig` to `{ type: "local", metadataOnly: true }`
+    * For `webhookKey` set `importConfig` as `{ type: "webhook", key: webhookKey}`
+  * Remove `parentId` and `blockImportIfErrors`
+
+
 ## 0.2.10 (React) (2022-11-09)
 
 * Fix Typescript definitions

--- a/packages/angular/projects/oneschema/package.json
+++ b/packages/angular/projects/oneschema/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@oneschema/angular",
   "private": false,
-  "version": "0.2.9",
+  "version": "0.3.0",
   "description": "Angular module for using OneSchema",
   "author": "OneSchema",
   "license": "MIT",
   "peerDependencies": {
     "@angular/common": "^14.1.0",
     "@angular/core": "^14.1.0",
-    "@oneschema/importer": "^0.2.9"
+    "@oneschema/importer": "^0.3.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/packages/importer/README.md
+++ b/packages/importer/README.md
@@ -35,11 +35,7 @@ const importer = oneschemaImporter({
   templateKey: 'YOUR_TEMPLATE_KEY',
   userJwt: 'YOUR_USER_JWT',
   /* optional */
-  webhookKey: 'YOUR_WEBHOOK_KEY',
-  config: {
-    blockImportIfErrors: true,
-    autofixAfterMapping: true,
-  },
+  importConfig: { type: "local" }
   devMode: true,
   className: 'oneschema-importer',
 })
@@ -50,11 +46,7 @@ importer.launch()
 importer.launch({
   templateKey: 'YOUR_TEMPLATE_KEY',
   userJwt: 'YOUR_USER_JWT',
-  webhookKey: 'YOUR_WEBHOOK_KEY',
-  config: {
-    blockImportIfErrors: true,
-    autofixAfterMapping: true,
-  },
+  importConfig: { type: "local" }
 })
 
 importer.on("success", (data) => {

--- a/packages/importer/package.json
+++ b/packages/importer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@oneschema/importer",
   "private": false,
-  "version": "0.2.9",
+  "version": "0.3.0",
   "description": "Importer for using OneSchema",
   "author": "OneSchema",
   "license": "MIT",

--- a/packages/importer/src/config.ts
+++ b/packages/importer/src/config.ts
@@ -1,94 +1,99 @@
 /**
- * Config options for how the OneSchema importer will behave
+ * Type for hex colors
  */
-export interface OneSchemaConfig {
+export type Hex = `#${string}`
+/**
+ * Type with options for mapping strategy customization
+ */
+export type MappingStrategy = "exact" | "fuzzy" | "historical"
+/**
+ * Type with options for import experience customization
+ */
+export type ImportExperience = "blockIfErrors" | "promptIfErrors" | "ignoreErrors"
+/**
+ * Type with options for sidebar details customization
+ */
+export type SidebarDetails = "required" | "all"
+
+/**
+ * Available customization settings for OneSchema
+ * For more information on a particular setting see https://docs.oneschema.co/docs/customizations
+ */
+export interface OneSchemaCustomization {
   /**
-   * Whether importing should be blocked if there are validation errors in the data
+   * styles
    */
-  blockImportIfErrors?: boolean
+  // GENERAL
+  primaryColor?: Hex
+  backgroundPrimaryColor?: Hex
+  backgroundSecondaryColor?: Hex
+  headerColor?: Hex
+  footerColor?: Hex
+  borderColor?: Hex
+  successColor?: Hex
+  warningColor?: Hex
+  errorColor?: Hex
+
+  // BUTTONS
+  buttonBorderRadius?: string
+  buttonPrimaryFillColor?: Hex
+  buttonPrimaryStrokeColor?: Hex
+  buttonPrimaryTextColor?: Hex
+  buttonSecondaryFillColor?: Hex
+  buttonSecondaryStrokeColor?: Hex
+  buttonSecondaryTextColor?: Hex
+  buttonTertiaryFillColor?: Hex
+  buttonTertiaryStrokeColor?: Hex
+  buttonTertiaryTextColor?: Hex
+  buttonAlertFillColor?: Hex
+  buttonAlertStrokeColor?: Hex
+  buttonAlertTextColor?: Hex
+
+  // FONTS
+  fontUrl?: string
+  fontFamily?: string
+  fontColorPrimary?: Hex
+  fontColorSecondary?: Hex
+  fontColorPlaceholder?: Hex
+
+  // MODAL
+  modalFullscreen?: boolean
+  modalMaskColor?: Hex
+  modalBorderRadius?: string
+  hideLogo?: boolean
+  illustrationUrl?: string
+
+  uploaderHeaderText?: string
+  uploaderSubheaderText?: string
+  uploaderShowSidebar?: boolean
+  uploaderSidebarDetails?: SidebarDetails
+  uploaderShowSidebarBanner?: boolean
+  uploaderSidebarBannerText?: string
+
+  includeExcelTemplate?: boolean
+  importExperience?: ImportExperience
+
   /**
-   * Whether fixable errors should automatically be fixed after the mapping headers step
+   * importer options
    */
-  autofixAfterMapping?: boolean
-  /**
-   * Whether suggestions from code hooks should be auto-accepted. Defaults to false
-   */
+  importUnmappedColumns?: boolean
+  mappingStrategy?: MappingStrategy[]
+  skipMapping?: MappingStrategy[]
   acceptCodeHookSuggestions?: boolean
-  /**
-   * Whether to skip exporting data to the onSuccess callback when not using a webhookKey
-   * Will return an object with a `sheet_id` key which can be used with external API calls
-   * to access the data
-   * Default to false.
-   */
-  skipExportData?: boolean
-  /**
-   * Options for specifying and/or modifying content displayed on different panes of the
-   * OneSchema Importer
-   */
-  contentOptions?: OneSchemaContentOptions
+  autofixAfterMapping?: boolean
 }
 
-/**
- * Options for specifying and/or modifying content displayed on different panes of the
- * OneSchema Importer
- */
-export interface OneSchemaContentOptions {
-  /**
-   * Options for the Upload a File step of the OneSchema Importer
-   */
-  upload?: OneSchemaUploadStepOptions
+export interface WebhookImportConfig {
+  type: "webhook"
+  key: string
 }
 
-/**
- * Options for content on the the Upload a File step of the OneSchema Importer
- */
-export interface OneSchemaUploadStepOptions {
-  /**
-   * Options to override the content in the uploader
-   */
-  uploader?: OneSchemaUploaderOptions
-  /**
-   * Options to specify information displayed in the uploader sidebar
-   */
-  infoSidebar?: OneSchemaUploadInfoSidebarOptions
+export interface LocalImportConfig {
+  type: "local"
+  metadataOnly?: boolean
 }
 
-/**
- * Options to override the content in the uploader
- */
-export interface OneSchemaUploaderOptions {
-  /**
-   * String override for the header in the uploader.
-   * Defaults to: "What data do you want to upload?"
-   */
-  header?: string
-  /**
-   * String override for the subheader in the uploader
-   * Defaults to: "Upload a CSV or Excel file to begin the import process"
-   */
-  subheader?: string
-}
-
-/**
- * Options to specify information displayed in the uploader sidebar
- */
-export interface OneSchemaUploadInfoSidebarOptions {
-  /**
-   * Whether to hide the info banner. Defaults to false.
-   */
-  hideInfoBanner?: boolean
-  /**
-   * Text to be displayed in the info banner
-   * Defaults to: "Make sure your file includes at least the following required columns:"
-   */
-  infoBannerText?: string
-  /**
-   * Specify which template columns to display in the info sidebar.
-   * "required" shows only columns that must be mapped
-   * "all" shows all columns on the template
-   */
-  displayTemplateColumns: "required" | "all"
-}
+export type ImportConfig = WebhookImportConfig | LocalImportConfig
 
 /**
  * Parameters that can be set when the OneSchema importer launches
@@ -104,14 +109,13 @@ export interface OneSchemaLaunchParams {
    */
   templateKey: string
   /**
-   * The key for the webhook that data from this import
-   * should be sent to. Setup inside OneSchema before using
+   * The configuration for how data should be impored from OneSchema
    */
-  webhookKey?: string
+  importConfig?: ImportConfig
   /**
-   * Config options for how the OneSchema importer will behave
+   * Customization options for how OneSchema will behave
    */
-  config?: OneSchemaConfig
+  customizationOverrides?: OneSchemaCustomization
 }
 
 /**
@@ -123,9 +127,9 @@ export interface OneSchemaLaunchSessionParams {
    */
   sessionToken: string
   /**
-   * Config options for how the OneSchema importer will behave
+   * Customization options for how OneSchema will behave
    */
-  config?: OneSchemaConfig
+  customizationOverrides?: OneSchemaCustomization
 }
 
 /**
@@ -218,8 +222,4 @@ export const DEFAULT_PARAMS: Partial<OneSchemaParams> = {
   className: "oneschema-iframe",
   autoClose: true,
   manageDOM: true,
-  config: {
-    blockImportIfErrors: true,
-    autofixAfterMapping: false,
-  },
 }

--- a/packages/importer/src/importer.ts
+++ b/packages/importer/src/importer.ts
@@ -144,7 +144,7 @@ export class OneSchemaImporterClass extends EventEmitter {
     const mergedParams = merge({}, this.#params, launchParams)
     const message: any = { messageType: "init" }
     message.manualClose = true
-    message.options = mergedParams.config
+    message.customizationOverrides = mergedParams.customizationOverrides
 
     message.userJwt = mergedParams.userJwt
     if (!message.userJwt) {
@@ -158,8 +158,8 @@ export class OneSchemaImporterClass extends EventEmitter {
       return { success: false, error: OneSchemaLaunchError.MissingTemplate }
     }
 
-    if (mergedParams.webhookKey) {
-      message.webhookKey = mergedParams.webhookKey
+    if (mergedParams.importConfig) {
+      message.importConfig = mergedParams.importConfig
     }
 
     this._launch(message)
@@ -177,7 +177,7 @@ export class OneSchemaImporterClass extends EventEmitter {
     const mergedParams = merge({}, this.#params, launchParams)
     const message: any = { messageType: "init-session" }
     message.manualClose = true
-    message.options = mergedParams.config
+    message.customizationOverrides = mergedParams.customizationOverrides
 
     message.sessionToken = mergedParams.sessionToken
     if (!message.sessionToken) {

--- a/packages/importer/src/index.ts
+++ b/packages/importer/src/index.ts
@@ -1,18 +1,4 @@
-export {
-  OneSchemaConfig,
-  OneSchemaContentOptions,
-  OneSchemaUploadStepOptions,
-  OneSchemaUploaderOptions,
-  OneSchemaUploadInfoSidebarOptions,
-  OneSchemaLaunchParams,
-  OneSchemaLaunchSessionParams,
-  OneSchemaLaunchError,
-  OneSchemaLaunchStatus,
-  OneSchemaInitParams,
-  OneSchemaLaunchParamOptions,
-  OneSchemaParams,
-  DEFAULT_PARAMS,
-} from "./config"
+export * from "./config"
 import oneSchemaImporter, { OneSchemaImporterClass } from "./importer"
 
 export { OneSchemaImporterClass }

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -43,11 +43,7 @@ function OneSchemaExample() {
         userJwt={token}
         templateKey={templateKey}
         /* optional config values */
-        webhookKey={webhookKey}
-        config={{
-          blockImportIfErrors: true,
-          autofixAfterMapping: true,
-        }}
+        importConfig={{ type: "local", metadataOnly: false, }}
         devMode={process.env.NODE_ENV !== "production"}
         className="oneschema-importer"
         style={{

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@oneschema/react",
   "private": false,
-  "version": "0.2.10",
+  "version": "0.3.0",
   "description": "React component for using OneSchema",
   "author": "OneSchema",
   "license": "MIT",
@@ -32,7 +32,7 @@
     "clean": "npx rimraf dist"
   },
   "dependencies": {
-    "@oneschema/importer": "^0.2.9"
+    "@oneschema/importer": "^0.3.0"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^22.0.0",

--- a/packages/react/src/OneSchemaImporter.tsx
+++ b/packages/react/src/OneSchemaImporter.tsx
@@ -24,14 +24,6 @@ export interface OneSchemaImporterBaseProps {
   languageCode?: string
   baseUrl?: string
   /**
-   * DEPRECATED: use config prop instead
-   */
-  blockImportIfErrors?: boolean
-  /**
-   * DEPRECATED: use inline prop instead
-   */
-  parentId?: string
-  /**
    * CSS styles that should be applied to the iframe
    */
   style?: React.CSSProperties
@@ -77,25 +69,8 @@ export default function OneSchemaImporter({
   onCancel,
   onError,
   onLaunched,
-
-  // deprecated
-  blockImportIfErrors,
-  parentId,
-
   ...params
 }: OneSchemaImporterProps) {
-  if (blockImportIfErrors !== undefined) {
-    console.warn(
-      "OneSchema prop 'blockImportIfErrors' is deprecated. Use 'config' prop instead",
-    )
-  }
-
-  if (parentId !== undefined) {
-    console.warn(
-      "OneSchema prop 'parentId' is deprecated. Use 'inline' prop, possibly with portal instead",
-    )
-  }
-
   const [importer] = useState(() => {
     const instance = oneschemaImporter({
       ...params,


### PR DESCRIPTION
* Updates to how config is specified with some breaking changes:
  * Add `customizationOverrides` and `importConfig` to params
  * Remove `config` and `webhookKey` from params. To migrate:
    * For most `config` values, pass them into `customizationOverride` or set on the [Customizations page](https://app.oneschema.co/customizations).
    * For `skipExportData` set `importConfig` to `{ type: "local", metadataOnly: true }`
    * For `webhookKey` set `importConfig` as `{ type: "webhook", key: webhookKey}`
  * Remove `parentId` and `blockImportIfErrors`