### PR TITLE
Update error handling and add HTTP errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ This log is intended to keep track of package changes, including
 but not limited to API changes and file location changes. Minor behavioral
 changes may not be included if they are not expected to break existing code.
 
+## 0.5.0 (2023-10-31)
+
+- Update `onError` payloads to return a `OneSchemaError`
+- Use `onError` for launch errors
+- Emit HTTP errors from `onError`
+
 ## 0.4.8 (2023-10-25)
 
 - Stop `_initWithRetry` if the postMessage has been recieved by OneSchema app.

--- a/packages/angular/projects/oneschema/package.json
+++ b/packages/angular/projects/oneschema/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@oneschema/angular",
   "private": false,
-  "version": "0.4.8",
+  "version": "0.5.0",
   "description": "Angular module for using OneSchema",
   "author": "OneSchema",
   "license": "MIT",
   "peerDependencies": {
     "@angular/common": "^14.1.0",
     "@angular/core": "^14.1.0",
-    "@oneschema/importer": "^0.4.8"
+    "@oneschema/importer": "^0.5.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/packages/importer/package.json
+++ b/packages/importer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@oneschema/importer",
   "private": false,
-  "version": "0.4.8",
+  "version": "0.5.0",
   "description": "Importer for using OneSchema",
   "author": "OneSchema",
   "license": "MIT",

--- a/packages/importer/src/config.ts
+++ b/packages/importer/src/config.ts
@@ -311,7 +311,7 @@ export interface OneSchemaError {
 }
 
 export enum OneSchemaErrorCode {
-  INITIALIZATION_ERROR = "initialization_error",
+  INITIALIZATION = "initialization",
   HTTP = "http",
 }
 

--- a/packages/importer/src/config.ts
+++ b/packages/importer/src/config.ts
@@ -304,15 +304,15 @@ export interface OneSchemaLaunchTemplateGroupParams {
   templateGroupKey: string
 }
 
-/**
- * Possible errors when launching OneSchema
- */
-export enum OneSchemaLaunchError {
-  MissingTemplate,
-  MissingJwt,
-  MissingSessionToken,
-  MissingTemplateGroup,
-  LaunchError,
+export interface ErrorPayload {
+  code: ErrorCode
+  message: string
+  data?: { [key: string]: any }
+}
+
+export enum ErrorCode {
+  INITIALIZATION_ERROR = "initialization_error",
+  HTTP = "http",
 }
 
 export interface OneSchemaLaunchStatus {
@@ -331,7 +331,7 @@ export interface OneSchemaLaunchStatus {
   /**
    * If success is false, this will be why it failed
    */
-  error?: OneSchemaLaunchError
+  error?: ErrorPayload
 }
 
 /**

--- a/packages/importer/src/config.ts
+++ b/packages/importer/src/config.ts
@@ -304,13 +304,13 @@ export interface OneSchemaLaunchTemplateGroupParams {
   templateGroupKey: string
 }
 
-export interface ErrorPayload {
-  code: ErrorCode
+export interface OneSchemaError {
+  code: OneSchemaErrorCode
   message: string
   data?: { [key: string]: any }
 }
 
-export enum ErrorCode {
+export enum OneSchemaErrorCode {
   INITIALIZATION_ERROR = "initialization_error",
   HTTP = "http",
 }
@@ -331,7 +331,7 @@ export interface OneSchemaLaunchStatus {
   /**
    * If success is false, this will be why it failed
    */
-  error?: ErrorPayload
+  error?: OneSchemaError
 }
 
 /**

--- a/packages/importer/src/importer.ts
+++ b/packages/importer/src/importer.ts
@@ -12,8 +12,8 @@ import {
   OneSchemaInitSimpleMessage,
   OneSchemaInitSessionMessage,
   FileUploadImportConfig,
-  ErrorPayload,
-  ErrorCode,
+  OneSchemaError,
+  OneSchemaErrorCode,
 } from "./config"
 import { version } from "../package.json"
 
@@ -185,7 +185,7 @@ export class OneSchemaImporterClass extends EventEmitter {
       }
       if (!message.userJwt) {
         const error = {
-          code: ErrorCode.INITIALIZATION_ERROR,
+          code: OneSchemaErrorCode.INITIALIZATION_ERROR,
           message: "OneSchema config error: missing userJwt",
         }
         this.emitErrorEvent(error)
@@ -205,7 +205,7 @@ export class OneSchemaImporterClass extends EventEmitter {
       }
       if (!message.userJwt) {
         const error = {
-          code: ErrorCode.INITIALIZATION_ERROR,
+          code: OneSchemaErrorCode.INITIALIZATION_ERROR,
           message: "OneSchema config error: missing userJwt",
         }
         this.emitErrorEvent(error)
@@ -214,7 +214,7 @@ export class OneSchemaImporterClass extends EventEmitter {
 
       if (!message.templateKey) {
         const error = {
-          code: ErrorCode.INITIALIZATION_ERROR,
+          code: OneSchemaErrorCode.INITIALIZATION_ERROR,
           message: "OneSchema config error: missing templateKey",
         }
         this.emitErrorEvent(error)
@@ -287,7 +287,7 @@ export class OneSchemaImporterClass extends EventEmitter {
         this.#show()
       } else {
         this.emitErrorEvent({
-          code: ErrorCode.INITIALIZATION_ERROR,
+          code: OneSchemaErrorCode.INITIALIZATION_ERROR,
           message: msg,
         })
         if (this.#params.autoClose) {
@@ -383,7 +383,7 @@ export class OneSchemaImporterClass extends EventEmitter {
       case "launch-error": {
         // need to update OS before message will be there
         this.emitErrorEvent({
-          code: ErrorCode.INITIALIZATION_ERROR,
+          code: OneSchemaErrorCode.INITIALIZATION_ERROR,
           message: event.data.message.message,
         })
         if (this.#params.autoClose) {
@@ -432,10 +432,10 @@ export class OneSchemaImporterClass extends EventEmitter {
 
         break
       }
-      // Only use for initialization errors
+      // Only used for initialization errors
       case "error": {
         this.emitErrorEvent({
-          code: ErrorCode.INITIALIZATION_ERROR,
+          code: OneSchemaErrorCode.INITIALIZATION_ERROR,
           message: event.data.message,
         })
 
@@ -446,7 +446,7 @@ export class OneSchemaImporterClass extends EventEmitter {
       }
       case "http-error": {
         this.emitErrorEvent({
-          code: ErrorCode.HTTP,
+          code: OneSchemaErrorCode.HTTP,
           message: event.data.data.message,
         })
         break
@@ -454,7 +454,7 @@ export class OneSchemaImporterClass extends EventEmitter {
     }
   }
 
-  emitErrorEvent(payload: ErrorPayload) {
+  emitErrorEvent(payload: OneSchemaError) {
     console.error(payload.message)
     this.emit("error", payload)
   }

--- a/packages/importer/src/importer.ts
+++ b/packages/importer/src/importer.ts
@@ -185,7 +185,7 @@ export class OneSchemaImporterClass extends EventEmitter {
       }
       if (!message.userJwt) {
         const error = {
-          code: OneSchemaErrorCode.INITIALIZATION_ERROR,
+          code: OneSchemaErrorCode.INITIALIZATION,
           message: "OneSchema config error: missing userJwt",
         }
         this.emitErrorEvent(error)
@@ -205,7 +205,7 @@ export class OneSchemaImporterClass extends EventEmitter {
       }
       if (!message.userJwt) {
         const error = {
-          code: OneSchemaErrorCode.INITIALIZATION_ERROR,
+          code: OneSchemaErrorCode.INITIALIZATION,
           message: "OneSchema config error: missing userJwt",
         }
         this.emitErrorEvent(error)
@@ -214,7 +214,7 @@ export class OneSchemaImporterClass extends EventEmitter {
 
       if (!message.templateKey) {
         const error = {
-          code: OneSchemaErrorCode.INITIALIZATION_ERROR,
+          code: OneSchemaErrorCode.INITIALIZATION,
           message: "OneSchema config error: missing templateKey",
         }
         this.emitErrorEvent(error)
@@ -287,7 +287,7 @@ export class OneSchemaImporterClass extends EventEmitter {
         this.#show()
       } else {
         this.emitErrorEvent({
-          code: OneSchemaErrorCode.INITIALIZATION_ERROR,
+          code: OneSchemaErrorCode.INITIALIZATION,
           message: msg,
         })
         if (this.#params.autoClose) {
@@ -381,9 +381,8 @@ export class OneSchemaImporterClass extends EventEmitter {
         break
       }
       case "launch-error": {
-        // need to update OS before message will be there
         this.emitErrorEvent({
-          code: OneSchemaErrorCode.INITIALIZATION_ERROR,
+          code: OneSchemaErrorCode.INITIALIZATION,
           message: event.data.message.message,
         })
         if (this.#params.autoClose) {
@@ -435,7 +434,7 @@ export class OneSchemaImporterClass extends EventEmitter {
       // Only used for initialization errors
       case "error": {
         this.emitErrorEvent({
-          code: OneSchemaErrorCode.INITIALIZATION_ERROR,
+          code: OneSchemaErrorCode.INITIALIZATION,
           message: event.data.message,
         })
 

--- a/packages/importer/src/importer.ts
+++ b/packages/importer/src/importer.ts
@@ -435,6 +435,10 @@ export class OneSchemaImporterClass extends EventEmitter {
         }
         break
       }
+      case "http-error": {
+        this.emit("http-error", event.data.data)
+        break
+      }
     }
   }
 }

--- a/packages/importer/test/index.ts
+++ b/packages/importer/test/index.ts
@@ -28,6 +28,11 @@ importer.on("cancel", () => {
   console.log("cancel")
 })
 
+importer.on("http-error", (e) => {
+  console.log(e)
+  alert("http error!")
+})
+
 importer.on("error", (e) => {
   console.log(e)
   alert("error!")

--- a/packages/importer/test/index.ts
+++ b/packages/importer/test/index.ts
@@ -28,11 +28,6 @@ importer.on("cancel", () => {
   console.log("cancel")
 })
 
-importer.on("http-error", (e) => {
-  console.log(e)
-  alert("http error!")
-})
-
 importer.on("error", (e) => {
   console.log(e)
   alert("error!")

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@oneschema/react",
   "private": false,
-  "version": "0.4.8",
+  "version": "0.5.0",
   "description": "React component for using OneSchema",
   "author": "OneSchema",
   "license": "MIT",
@@ -32,7 +32,7 @@
     "clean": "npx rimraf dist"
   },
   "dependencies": {
-    "@oneschema/importer": "^0.4.8"
+    "@oneschema/importer": "^0.5.0"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^22.0.0",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@oneschema/vue",
   "private": false,
-  "version": "0.4.8",
+  "version": "0.5.0",
   "description": "Vue plugin for using OneSchema",
   "author": "OneSchema",
   "license": "MIT",
@@ -32,7 +32,7 @@
     "clean": "npx rimraf dist"
   },
   "dependencies": {
-    "@oneschema/importer": "^0.4.8"
+    "@oneschema/importer": "^0.5.0"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^22.0.0",


### PR DESCRIPTION
This makes it so there is only a single "error" event. The payload in each error event contains a code (currently either `INITIALIZATION` or `HTTP`), a message, and an optional data object.

If this PR looks OK, I will make the updates to the docs.