### PR TITLE
Error payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This log is intended to keep track of package changes, including
 but not limited to API changes and file location changes. Minor behavioral
 changes may not be included if they are not expected to break existing code.
 
+## 0.5.0 (2023-12-04)
+
+- Update error payloads to be Objects
+
 ## 0.4.11 (2023-11-09)
 
 - Bugfix for issue with errors

--- a/packages/angular/projects/oneschema/README.md
+++ b/packages/angular/projects/oneschema/README.md
@@ -80,7 +80,7 @@ export class OneSchemaButton implements OnDestroy {
     // handle success
   }
 
-  onError(message: string) {
+  onError(error: any) {
     // handle error
   }
 

--- a/packages/angular/projects/oneschema/package.json
+++ b/packages/angular/projects/oneschema/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@oneschema/angular",
   "private": false,
-  "version": "0.4.11",
+  "version": "0.5.0",
   "description": "Angular module for using OneSchema",
   "author": "OneSchema",
   "license": "MIT",
   "peerDependencies": {
     "@angular/common": "^14.1.0",
     "@angular/core": "^14.1.0",
-    "@oneschema/importer": "^0.4.11"
+    "@oneschema/importer": "^0.5.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/packages/angular/projects/oneschema/src/lib/oneschema.samples.ts
+++ b/packages/angular/projects/oneschema/src/lib/oneschema.samples.ts
@@ -33,7 +33,7 @@ export class OneSchemaListener implements OnDestroy {
     // handle success
   }
 
-  onError(message: string) {
+  onError(error: any) {
     // handle error
   }
 

--- a/packages/importer/package.json
+++ b/packages/importer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@oneschema/importer",
   "private": false,
-  "version": "0.4.11",
+  "version": "0.5.0",
   "description": "Importer for using OneSchema",
   "author": "OneSchema",
   "license": "MIT",

--- a/packages/importer/src/config.ts
+++ b/packages/importer/src/config.ts
@@ -466,3 +466,13 @@ export const DEFAULT_PARAMS: Partial<OneSchemaParams> = {
   manageDOM: true,
   saveSession: true,
 }
+
+export enum OneSchemaErrorSeverity {
+    Error = "error",
+    Fatal = "fatal",
+}
+
+export interface OneSchemaError {
+  message: string
+  severity: OneSchemaErrorSeverity
+}

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -57,7 +57,7 @@ function OneSchemaExample() {
         /* handling results */
         onSuccess={handleData}
         onCancel={() => console.log("cancelled")}
-        onError={(message) => console.log(message)}
+        onError={(error) => console.log(error)}
       />
     </div>
   )

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@oneschema/react",
   "private": false,
-  "version": "0.4.11",
+  "version": "0.5.0",
   "description": "React component for using OneSchema",
   "author": "OneSchema",
   "license": "MIT",
@@ -32,7 +32,7 @@
     "clean": "npx rimraf dist"
   },
   "dependencies": {
-    "@oneschema/importer": "^0.4.11"
+    "@oneschema/importer": "^0.5.0"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^22.0.0",

--- a/packages/react/src/OneSchemaImporter.tsx
+++ b/packages/react/src/OneSchemaImporter.tsx
@@ -1,5 +1,7 @@
 import React, { useCallback, useEffect, useRef, useState } from "react"
 import oneschemaImporter, {
+  OneSchemaError,
+  OneSchemaErrorSeverity,
   OneSchemaLaunchParamOptions,
   OneSchemaLaunchStatus,
 } from "@oneschema/importer"
@@ -45,7 +47,7 @@ export interface OneSchemaImporterBaseProps {
   /**
    * Handler for when an error occurs during the import
    */
-  onError?: (message: string) => void
+  onError?: (error: OneSchemaError) => void
   /**
    * Handler for when the importer is launched (aka is ready to be shown)
    * Or when launching fails, based on result
@@ -103,15 +105,9 @@ export default function OneSchemaImporter({
         onRequestClose && onRequestClose()
       })
 
-      importer.on("error", (message: string) => {
-        onError && onError(message)
-        // We don't want to close the importer on these errors.
-        // TODO: This is super hacky and we need to find a better way to emit errors
-        // without calling `onRequestClose`.
-        if (
-          !message.includes("File upload failed") &&
-          !message.includes("Validation webhook failed")
-        ) {
+      importer.on("error", (error: OneSchemaError) => {
+        onError && onError(error)
+        if (error.severity === OneSchemaErrorSeverity.Fatal) {
           onRequestClose && onRequestClose()
         }
       })

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@oneschema/vue",
   "private": false,
-  "version": "0.4.11",
+  "version": "0.5.0",
   "description": "Vue plugin for using OneSchema",
   "author": "OneSchema",
   "license": "MIT",
@@ -32,7 +32,7 @@
     "clean": "npx rimraf dist"
   },
   "dependencies": {
-    "@oneschema/importer": "^0.4.11"
+    "@oneschema/importer": "^0.5.0"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^22.0.0",

--- a/packages/vue/test/OneSchemaImporter.vue
+++ b/packages/vue/test/OneSchemaImporter.vue
@@ -15,7 +15,7 @@
       // TODO: handle cancel
     });
 
-    importer.on('error', (message) => {
+    importer.on('error', (error) => {
       // TODO: handle errors
       console.log(message);
     });


### PR DESCRIPTION
This creates a type `OneSchemaError` which includes an error message and a severity and uses it in `onError` callback.  The severity is used to determine if we should trigger the existing autoclose functionality. This approach is
* easy for us since we don't have to change any of the existing autoclose/onRequestClose logic
* easy for users since it's easy to migrate to
