### PR TITLE
Enable customization key and overrides for Embedded File Feeds

### DIFF
--- a/CHANGELOG-filefeeds.md
+++ b/CHANGELOG-filefeeds.md
@@ -7,6 +7,10 @@ This log is intended to keep track of package changes, including
 but not limited to API changes and file location changes. Minor behavioral
 changes may not be included if they are not expected to break existing code.
 
+## 0.4.0 (2024-09-06)
+
+- Support `customization_key` and `customization_overrides` as launch parameters
+
 ## 0.3.0 (2024-08-29)
 
 - Support `cancelled` event. (React: `onCancel` callback.)

--- a/packages/filefeeds-react/package.json
+++ b/packages/filefeeds-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@oneschema/filefeeds-react",
   "private": false,
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "React component for embedding OneSchema FileFeeds",
   "author": "OneSchema",
   "license": "MIT",

--- a/packages/filefeeds-react/src/OneSchemaFileFeeds.tsx
+++ b/packages/filefeeds-react/src/OneSchemaFileFeeds.tsx
@@ -10,7 +10,9 @@ import oneschemaFileFeeds, {
   SavedEventData,
   SessionInvalidatedEventData,
   ShownEventData,
+  OneSchemaCustomization,
 } from "@oneschema/filefeeds"
+
 import React, { useCallback, useEffect, useRef, useState } from "react"
 
 import { name as PACKAGE_NAME, version as PACKAGE_VERSION } from "../package.json"
@@ -54,6 +56,15 @@ export interface OneSchemaFileFeedsProps {
    */
   onRequestClose?: () => void
 
+  /**
+   * The customization key to use when launching the FileFeeds Transforms.
+   */
+  customizationKey?: string
+
+  /**
+   * The customization overrides to use when launching
+   */
+  customizationOverrides?: OneSchemaCustomization
   /**
    * Handler for when the embedded FileFeeds page is loaded behind the scenes.
    */
@@ -129,6 +140,9 @@ export default function OneSchemaFileFeeds({
   onRequestClose,
   style,
   className,
+  // Launch props
+  customizationKey,
+  customizationOverrides,
   // == Events props ==
   // Iframe
   onPageLoad,
@@ -229,7 +243,7 @@ export default function OneSchemaFileFeeds({
   // Manage show and hide of the iframe.
   useEffect(() => {
     if (isOpen) {
-      instance?.launch()
+      instance?.launch({ userJwt, customizationKey, customizationOverrides })
     } else {
       instance?.hide()
     }

--- a/packages/filefeeds/package.json
+++ b/packages/filefeeds/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@oneschema/filefeeds",
   "private": false,
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "OneSchema FileFeeds embedding library",
   "author": "OneSchema",
   "license": "MIT",

--- a/packages/filefeeds/src/config.ts
+++ b/packages/filefeeds/src/config.ts
@@ -214,9 +214,18 @@ export interface FileFeedsLaunchParams {
    * The JSON Web Token authenticating the user, and authorizing them to access
    * specific OneSchema FileFeeds embedding intents.
    */
-  userJwt: string
-  customizationKey: string
-  customizationOverrides: OneSchemaCustomization
+  userJwt?: string
+
+  /**
+   * The customization key. Use this to specify which OneSchema customization to use. Use
+   * the default customization if none specified.
+   */
+  customizationKey?: string
+
+  /**
+   * A hash of overrides to modify specific customization values.
+   */
+  customizationOverrides?: OneSchemaCustomization
 }
 
 /**

--- a/packages/filefeeds/src/config.ts
+++ b/packages/filefeeds/src/config.ts
@@ -1,4 +1,156 @@
 /**
+ * Type for hex colors
+ */
+export type Hex = `#${string}`
+/**
+ * Type with options for mapping strategy customization
+ */
+export type MappingStrategy =
+  | "exact"
+  | "fuzzy"
+  | "historical_user"
+  | "historical_org"
+  | "historical" // historical is deprecated
+/**
+ * Type with options for skipping the header row step
+ */
+export type SkipHeaderRowStrategy = "always" | "detect" | "never"
+/**
+ * Type with options for allowing row deletion
+ */
+export type RowDeletionStrategy = "selection" | "errors"
+/**
+ * Type with options for AI suggested mappings customization
+ */
+export type AiSuggestedMappings = "column" | "picklist"
+/**
+ * Type with options for import experience customization
+ */
+export type ImportExperience = "blockIfErrors" | "promptIfErrors" | "ignoreErrors"
+/**
+ * Type with options for sidebar details customization
+ */
+export type SidebarDetails = "required" | "all"
+/**
+ * Available customization settings for OneSchema
+ * For more information on a particular setting see https://docs.oneschema.co/docs/customizations
+ */
+export interface OneSchemaCustomization {
+  /**
+   * styles
+   */
+  // GENERAL
+  primaryColor?: Hex
+  backgroundPrimaryColor?: Hex
+  backgroundSecondaryColor?: Hex
+  headerColor?: Hex
+  footerColor?: Hex
+  borderColor?: Hex
+  successColor?: Hex
+  warningColor?: Hex
+  errorColor?: Hex
+
+  // BUTTONS
+  buttonBorderRadius?: string
+  buttonPrimaryFillColor?: Hex
+  buttonPrimaryStrokeColor?: Hex
+  buttonPrimaryTextColor?: Hex
+  buttonSecondaryFillColor?: Hex
+  buttonSecondaryStrokeColor?: Hex
+  buttonSecondaryTextColor?: Hex
+  buttonTertiaryFillColor?: Hex
+  buttonTertiaryStrokeColor?: Hex
+  buttonTertiaryTextColor?: Hex
+  buttonAlertFillColor?: Hex
+  buttonAlertStrokeColor?: Hex
+  buttonAlertTextColor?: Hex
+
+  // FONTS
+  fontUrl?: string
+  fontFamily?: string
+  fontColorPrimary?: Hex
+  fontColorSecondary?: Hex
+  fontColorPlaceholder?: Hex
+
+  /**
+   * options
+   */
+  // IMPORTER OPTIONS
+  hideLogo?: boolean
+  modalFullscreen?: boolean
+  hideCloseButton?: boolean
+  modalMaskColor?: Hex
+  modalBorderRadius?: string
+
+  // UPLOAD PANE
+  fileSizeLimit?: number
+  illustrationUrl?: string
+  uploaderShowSidebar?: boolean
+  uploaderSidebarDetails?: SidebarDetails
+  uploaderShowSidebarBanner?: boolean
+  uploaderSidebarBannerText?: string
+  includeExcelTemplate?: boolean
+
+  // SELECT HEADER ROW PANE
+  skipHeaderRow?: SkipHeaderRowStrategy
+
+  // MAP COLUMNS PANE
+  includeUnmappedColumns?: boolean
+  mappingStrategy?: MappingStrategy[]
+  skipMapping?: MappingStrategy[]
+  aiSuggestedMappings?: AiSuggestedMappings[]
+  oneClickMode?: boolean
+  mappingShowSidebar?: boolean
+  mappingSidebarDetails?: SidebarDetails
+  mappingShowSidebarBanner?: boolean
+  mappingSidebarBannerText?: string | null
+
+  // REVIEW AND FINALIZE PANE
+  autofixAfterMapping?: boolean
+  acceptCodeHookSuggestions?: boolean
+  preventRowDeletion?: RowDeletionStrategy[]
+  importErrorUX?: ImportExperience
+  skipCleaning?: boolean
+  allowEmptyImports?: boolean
+  importMaxRowLimit?: number | null
+  importRowLimitHeader?: string | null
+  importRowLimitDescription?: string | null
+
+  // EDUCATION WIDGET
+  showUploadEducationWidget?: boolean
+  uploadEducationWidgetMessage?: string
+  uploadEducationWidgetAutoOpen?: boolean
+  showSetHeaderEducationWidget?: boolean
+  setHeaderEducationWidgetMessage?: string
+  setHeaderEducationWidgetAutoOpen?: boolean
+  showMappingEducationWidget?: boolean
+  mappingEducationWidgetMessage?: string
+  mappingEducationWidgetAutoOpen?: boolean
+  showCleaningEducationWidget?: boolean
+  cleaningEducationWidgetMessage?: string
+  cleaningEducationWidgetAutoOpen?: boolean
+
+  /**
+   * Text overrides
+   */
+  backButtonText?: string
+  nextButtonText?: string
+  uploadPaneHeaderText?: string
+  uploaderHeaderText?: string
+  uploaderSubheaderText?: string
+  setHeaderPaneHeaderText?: string
+  mappingPaneHeaderText?: string
+  mappingUploadedColumnText?: string
+  mappingTemplateColumnText?: string
+  cleaningPaneHeaderText?: string
+  cleaningConfirmButtonText?: string
+  picklistMappingHeaderText?: string
+  picklistMappingSubheaderText?: string
+  picklistMappingUploadedColumnText?: string
+  picklistMappingTemplateColumnText?: string
+}
+
+/**
  * The default param values for the OneSchema FileFeeds.
  */
 export const DEFAULT_PARAMS: Partial<FileFeedsParams> = {
@@ -55,6 +207,16 @@ export interface FileFeedsParams {
    * Defaults to the US OneSchema production servers.
    */
   baseUrl?: string
+}
+
+export interface FileFeedsLaunchParams {
+  /**
+   * The JSON Web Token authenticating the user, and authorizing them to access
+   * specific OneSchema FileFeeds embedding intents.
+   */
+  userJwt: string
+  customizationKey: string
+  customizationOverrides: OneSchemaCustomization
 }
 
 /**

--- a/packages/filefeeds/src/filefeeds.ts
+++ b/packages/filefeeds/src/filefeeds.ts
@@ -2,7 +2,7 @@ import { EventEmitter } from "eventemitter3"
 import merge from "lodash.merge"
 
 import { name as PACKAGE_NAME, version as PACKAGE_VERSION } from "../package.json"
-import { DEFAULT_PARAMS, FileFeedsParams } from "./config"
+import { DEFAULT_PARAMS, FileFeedsLaunchParams, FileFeedsParams } from "./config"
 import { FileFeedsEvent } from "./events"
 
 const LAUNCH_RETRY_MAX_COUNT = 10
@@ -16,6 +16,7 @@ const FILE_FEEDS_TRANSFORMS_EMBED_MARKER = "transforms.filefeeds.oneschema.co"
  */
 export class OneSchemaFileFeedsClass extends EventEmitter {
   #params: FileFeedsParams
+  #launchParams: Partial<FileFeedsLaunchParams> = {}
   iframe: HTMLIFrameElement | undefined
 
   #client = PACKAGE_NAME
@@ -140,13 +141,15 @@ export class OneSchemaFileFeedsClass extends EventEmitter {
   /**
    * Launch will show the OneSchema window and initialize the FileFeeds session.
    */
-  launch(): void {
+  launch(params: Partial<FileFeedsLaunchParams>): void {
     if (this._iframeIsDestroyed) {
       if (this.#params.devMode) {
         console.error("[OSFF] Instance has been destroyed.")
       }
       return
     }
+
+    this.#launchParams = params
 
     if (OneSchemaFileFeedsClass.#iframeIsLoaded) {
       this._initWithRetry()
@@ -176,7 +179,7 @@ export class OneSchemaFileFeedsClass extends EventEmitter {
     }
 
     this.#show()
-    this.#iframeEventEmit("init", {})
+    this.#iframeEventEmit("init", this.#launchParams || {})
 
     setTimeout(() => this._initWithRetry(retryCount + 1), LAUNCH_RETRY_DELAY_MS)
   }

--- a/packages/filefeeds/test/index.ts
+++ b/packages/filefeeds/test/index.ts
@@ -16,7 +16,7 @@ const fileFeeds = oneSchemaFileFeeds({
   parentId: "oneschema-container",
   baseUrl: "http://embed.localschema.co:9450",
   userJwt:
-    "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiI2N2JiMmU1Zi1mMGY3LTQyYTYtYTUxMS0xOGIyNWU2N2I4YzQiLCJ1c2VyX2lkIjoiPFVTRVJfSUQ-IiwiY3JlYXRlIjp7InNlc3Npb24iOnsiZmlsZV9mZWVkX2lkIjoyOTM3Nn19fQ.BgpLx_kmW2HWMu2dzcw1pMKBm3LNsXXJzAgmZt1rNuA",
+    "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiI4MDMyYWY0Yi1lMmQ5LTQwYWQtODE0Mi1lNjgwMTFkOTRkOWMiLCJ1c2VyX2lkIjoiPFVTRVJfSUQ-IiwiY3JlYXRlIjp7ImZpbGVfZmVlZCI6eyJuYW1lIjoiY3JtX3Rlc3RfMTcyNTQ5MTQ1ODA1OCIsInRlbXBsYXRlX2tleSI6ImNybV90ZXN0IiwiY3VzdG9tX21ldGFkYXRhIjp7fX19fQ.4izMP5MzlfxryMqpsJWW1o_fnpyMpG_EYLN12jObO-g",
   devMode: true,
   styles: {
     display: "flex",
@@ -30,7 +30,7 @@ const fileFeeds = oneSchemaFileFeeds({
 statusEl.innerHTML = "Loading in the background."
 
 document.getElementById("launch-button")!.onclick = () => {
-  fileFeeds.launch()
+  fileFeeds.launch({ customizationOverrides: { backgroundPrimaryColor: "#FF00FF" } })
 }
 
 document.getElementById("hide-button")!.onclick = () => {


### PR DESCRIPTION
Allow users to pass in `customization_key` and `customization_overrides` as launch params to embedded file feeds