### PR TITLE
expose session token on success payload and as init parameter

### DIFF
--- a/packages/filefeeds/src/config.ts
+++ b/packages/filefeeds/src/config.ts
@@ -229,6 +229,13 @@ export interface FileFeedsLaunchParams {
 }
 
 /**
+ * Parameters that can be set when OneSchema launches with a sessionToken
+ */
+export interface FileFeedsLaunchSessionParams {
+  sessionToken: string
+}
+
+/**
  * Possible errors when launching OneSchema
  */
 export enum FileFeedsLaunchError {

--- a/packages/filefeeds/src/events.ts
+++ b/packages/filefeeds/src/events.ts
@@ -28,6 +28,8 @@ export interface InitFailedEventData {
 }
 
 export interface InitSucceededEventData {
+  sessionToken: string
+  // TODO: remove session_id
   sessionId: number
   fileFeed: {
     name: string

--- a/packages/filefeeds/src/filefeeds.ts
+++ b/packages/filefeeds/src/filefeeds.ts
@@ -2,7 +2,7 @@ import { EventEmitter } from "eventemitter3"
 import merge from "lodash.merge"
 
 import { name as PACKAGE_NAME, version as PACKAGE_VERSION } from "../package.json"
-import { DEFAULT_PARAMS, FileFeedsLaunchParams, FileFeedsParams } from "./config"
+import { DEFAULT_PARAMS, FileFeedsLaunchParams, FileFeedsLaunchSessionParams, FileFeedsParams } from "./config"
 import { FileFeedsEvent } from "./events"
 
 const LAUNCH_RETRY_MAX_COUNT = 10
@@ -16,7 +16,7 @@ const FILE_FEEDS_TRANSFORMS_EMBED_MARKER = "transforms.filefeeds.oneschema.co"
  */
 export class OneSchemaFileFeedsClass extends EventEmitter {
   #params: FileFeedsParams
-  #launchParams: Partial<FileFeedsLaunchParams> = {}
+  #launchParams: Partial<FileFeedsLaunchParams> & Partial<FileFeedsLaunchSessionParams>= {}
   iframe: HTMLIFrameElement | undefined
 
   #client = PACKAGE_NAME
@@ -141,7 +141,7 @@ export class OneSchemaFileFeedsClass extends EventEmitter {
   /**
    * Launch will show the OneSchema window and initialize the FileFeeds session.
    */
-  launch(params: Partial<FileFeedsLaunchParams>): void {
+  launch(params: Partial<FileFeedsLaunchParams> & Partial<FileFeedsLaunchSessionParams>): void {
     if (this._iframeIsDestroyed) {
       if (this.#params.devMode) {
         console.error("[OSFF] Instance has been destroyed.")


### PR DESCRIPTION
Expose session token on `init-sucess` event payload