### PR TITLE
Allow initialization of an FileFeed embed session via session token

### DIFF
--- a/packages/filefeeds-react/package.json
+++ b/packages/filefeeds-react/package.json
@@ -32,7 +32,7 @@
     "clean": "npx rimraf dist"
   },
   "dependencies": {
-    "@oneschema/filefeeds": "^0.2.3",
+    "@oneschema/filefeeds": "^0.4.0",
     "tslib": "^2.4.0"
   },
   "devDependencies": {

--- a/packages/filefeeds-react/src/OneSchemaFileFeeds.tsx
+++ b/packages/filefeeds-react/src/OneSchemaFileFeeds.tsx
@@ -250,7 +250,12 @@ export default function OneSchemaFileFeeds({
   useEffect(
     () => {
       if (isOpen) {
-        instance?.launch({userJwt, sessionToken, customizationKey, customizationOverrides})
+        instance?.launch({
+          userJwt,
+          sessionToken,
+          customizationKey,
+          customizationOverrides,
+        })
       } else {
         instance?.hide()
       }

--- a/packages/filefeeds-react/src/OneSchemaFileFeeds.tsx
+++ b/packages/filefeeds-react/src/OneSchemaFileFeeds.tsx
@@ -29,6 +29,11 @@ export interface OneSchemaFileFeedsProps {
   devMode?: boolean
 
   /**
+   * Whether to use a session token to resume an existing session.
+   */
+  sessionToken?: string
+
+  /**
    * Whether the iframe should be rendered in the component tree
    * If false or not set, the iframe will append to document.body
    *
@@ -143,6 +148,8 @@ export default function OneSchemaFileFeeds({
   // Launch props
   customizationKey,
   customizationOverrides,
+  // Init Session props
+  sessionToken,
   // == Events props ==
   // Iframe
   onPageLoad,
@@ -244,7 +251,7 @@ export default function OneSchemaFileFeeds({
   useEffect(
     () => {
       if (isOpen) {
-        instance?.launch({ userJwt, customizationKey, customizationOverrides })
+        instance?.launch({userJwt, sessionToken, customizationKey, customizationOverrides})
       } else {
         instance?.hide()
       }

--- a/packages/filefeeds-react/src/OneSchemaFileFeeds.tsx
+++ b/packages/filefeeds-react/src/OneSchemaFileFeeds.tsx
@@ -136,6 +136,7 @@ export interface OneSchemaFileFeedsProps {
  */
 export default function OneSchemaFileFeeds({
   // Primary props
+  sessionToken,
   userJwt,
   baseUrl,
   devMode = false,
@@ -148,8 +149,6 @@ export default function OneSchemaFileFeeds({
   // Launch props
   customizationKey,
   customizationOverrides,
-  // Init Session props
-  sessionToken,
   // == Events props ==
   // Iframe
   onPageLoad,

--- a/packages/filefeeds-react/test/index.tsx
+++ b/packages/filefeeds-react/test/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from "react"
+import React, { useCallback, useEffect, useState } from "react"
 import { createRoot } from "react-dom/client"
 
 import OneSchemaFileFeeds from "../src"
@@ -14,6 +14,15 @@ function TestApp() {
   }, [])
 
   const [sessionId, setSessionId] = useState<number | null>(null)
+  const [sessionToken, setSessionToken] = useState<string | null>(null)
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search)
+    const token = params.get("sessionToken")
+    if (token) {
+      setSessionToken(token)
+    }
+  }, [])
 
   return (
     <>
@@ -38,6 +47,10 @@ function TestApp() {
           <span>
             Session ID: <code>{sessionId ?? "—"}</code>
           </span>
+          &nbsp; / &nbsp;
+          <span>
+            Session Token: <code>{sessionToken ?? "—"}</code>
+          </span>
         </p>
       </header>
 
@@ -45,7 +58,8 @@ function TestApp() {
         {preloadIframe && (
           <OneSchemaFileFeeds
             baseUrl="http://embed.localschema.co:9450"
-            userJwt="eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiI2N2JiMmU1Zi1mMGY3LTQyYTYtYTUxMS0xOGIyNWU2N2I4YzQiLCJ1c2VyX2lkIjoiPFVTRVJfSUQ-IiwiY3JlYXRlIjp7InNlc3Npb24iOnsiZmlsZV9mZWVkX2lkIjoyOTM3Nn19fQ.BgpLx_kmW2HWMu2dzcw1pMKBm3LNsXXJzAgmZt1rNuA"
+            userJwt="eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiI1ZmU4MTRjNi0zNDVlLTRhZTctYTI3YS01MDNhMzU0MzY2MjYiLCJ1c2VyX2lkIjoiPFVTRVJfSUQ-IiwiY3JlYXRlIjp7InNlc3Npb24iOnsiZmlsZV9mZWVkX2lkIjo1Mjk3Nn19fQ.9hM5ZRDWTXBHD7g0sw6G_wcI61Gl503lquXfzr-1RnI"
+            sessionToken={sessionToken ?? undefined}
             devMode
             style={{
               border: "0",
@@ -65,10 +79,12 @@ function TestApp() {
             onInitFail={(data) => updateStatus("Initialization failed.", data)}
             onInitSucceed={(data) => {
               setSessionId(data.sessionId)
+              setSessionToken(data.sessionToken)
               updateStatus("Initialization succeeded.", data)
             }}
             onDestroy={(data) => {
               setSessionId(null)
+              setSessionToken(null)
               updateStatus("Destroyed.", data)
             }}
             onHide={(data) => updateStatus("Hidden.", data)}

--- a/packages/filefeeds/src/config.ts
+++ b/packages/filefeeds/src/config.ts
@@ -31,6 +31,11 @@ export interface FileFeedsParams {
   userJwt: string
 
   /**
+   * The session token to use when launching OneSchema FileFeeds.
+   */
+  sessionToken?: string
+
+  /**
    * Whether to launch the OneSchema FileFeeds in dev mode.
    *
    * Defaults to false when `process.env.NODE_ENV` is "production", and true

--- a/packages/filefeeds/src/config.ts
+++ b/packages/filefeeds/src/config.ts
@@ -25,15 +25,15 @@ export const DEFAULT_PARAMS: Partial<FileFeedsParams> = {
  */
 export interface FileFeedsParams {
   /**
+   * The session token to use when launching OneSchema FileFeeds.
+   */
+  sessionToken?: string
+
+  /**
    * The JSON Web Token authenticating the user, and authorizing them to access
    * specific OneSchema FileFeeds embedding intents.
    */
   userJwt: string
-
-  /**
-   * The session token to use when launching OneSchema FileFeeds.
-   */
-  sessionToken?: string
 
   /**
    * Whether to launch the OneSchema FileFeeds in dev mode.

--- a/packages/filefeeds/src/events.ts
+++ b/packages/filefeeds/src/events.ts
@@ -28,6 +28,8 @@ export interface InitFailedEventData {
 }
 
 export interface InitSucceededEventData {
+  sessionToken: string
+  // TODO: remove sessionId
   sessionId: number
   fileFeed: {
     name: string

--- a/packages/filefeeds/src/filefeeds.ts
+++ b/packages/filefeeds/src/filefeeds.ts
@@ -154,8 +154,9 @@ export class OneSchemaFileFeedsClass extends EventEmitter {
 
     const mergedParams = { ...this.#params, ...params }
 
+    this.#resumeTokenKey = `OneSchemaFileFeeds-session-${this.#params.userJwt}`
+
     try {
-      this.#resumeTokenKey = `OneSchemaFileFeeds-${this.#params.userJwt}`
       const resumeToken = window.localStorage.getItem(this.#resumeTokenKey)
       if (resumeToken) {
         this.#launchParams.sessionToken = resumeToken
@@ -327,13 +328,11 @@ export class OneSchemaFileFeedsClass extends EventEmitter {
 
       case "init-succeeded": {
         this._iframeInitSucceeded = true
-        const sessionToken = eventData.sessionToken
-        if (this.#resumeTokenKey && sessionToken) {
-          try {
-            window.localStorage.setItem(this.#resumeTokenKey, sessionToken)
-          } catch {
-            /* local storage is not available, don't sweat it */
-          }
+        const { sessionToken } = eventData
+        try {
+          window.localStorage.setItem(this.#resumeTokenKey, sessionToken)
+        } catch {
+          /* local storage is not available, don't sweat it */
         }
         break
       }

--- a/packages/filefeeds/src/filefeeds.ts
+++ b/packages/filefeeds/src/filefeeds.ts
@@ -154,15 +154,17 @@ export class OneSchemaFileFeedsClass extends EventEmitter {
 
     const mergedParams = { ...this.#params, ...params }
 
-    this.#resumeTokenKey = `OneSchemaFileFeeds-session-${this.#params.userJwt}`
+    this.#resumeTokenKey = `OneSchemaFileFeeds-session-${mergedParams.userJwt}`
 
-    try {
-      const resumeToken = window.localStorage.getItem(this.#resumeTokenKey)
-      if (resumeToken) {
-        this.#launchParams.sessionToken = resumeToken
+    if (!mergedParams.sessionToken) {
+      try {
+        const resumeToken = window.localStorage.getItem(this.#resumeTokenKey)
+        if (resumeToken) {
+          mergedParams.sessionToken = resumeToken
+        }
+      } catch {
+          /* local storage is not available, don't sweat it */
       }
-    } catch {
-        /* local storage is not available, don't sweat it */
     }
 
     if (OneSchemaFileFeedsClass.#iframeIsLoaded) {
@@ -193,6 +195,11 @@ export class OneSchemaFileFeedsClass extends EventEmitter {
     }
 
     this.#show()
+
+    if (params.sessionToken) {
+      params = { sessionToken: params.sessionToken, userJwt: params.userJwt }
+    }
+
     this.#iframeEventEmit("init", params)
 
     setTimeout(() => this._initWithRetry(params, retryCount + 1), LAUNCH_RETRY_DELAY_MS)

--- a/packages/filefeeds/src/filefeeds.ts
+++ b/packages/filefeeds/src/filefeeds.ts
@@ -11,7 +11,7 @@ const FILE_FEEDS_TRANSFORMS_EMBED_MARKER = "transforms.filefeeds.oneschema.co"
 
 type FileFeedsLaunchParams = Pick<
   FileFeedsParams,
-  "userJwt" | "customizationKey" | "customizationOverrides"
+  "userJwt" | "customizationKey" | "customizationOverrides" | "sessionToken"
 >
 
 /**

--- a/packages/filefeeds/test/index.html
+++ b/packages/filefeeds/test/index.html
@@ -36,6 +36,10 @@
         <span style="display: inline-block; padding-right: 0 1em"
           >Session ID: <code id="session-id">&mdash;</code></span
         >
+        &nbsp;/&nbsp;
+        <span style="display: inline-block; padding-right: 0 1em"
+          >Session Token: <code id="session-token">&mdash;</code></span
+        >
       </p>
     </header>
 

--- a/packages/filefeeds/test/index.ts
+++ b/packages/filefeeds/test/index.ts
@@ -2,12 +2,29 @@ import oneSchemaFileFeeds from "../src"
 
 const statusEl = document.getElementById("status")!
 const sessionIdEl = document.getElementById("session-id")!
+const sessionTokenEl = document.getElementById("session-token")!
+
+function getQueryParams() {
+  const params = new URLSearchParams(window.location.search)
+  const sessionToken = params.get("sessionToken")
+
+  return { sessionToken }
+}
+
+const { sessionToken } = getQueryParams()
+
+if (sessionToken) {
+  sessionTokenEl.innerHTML = sessionToken
+}
 
 function updateStatus(message: string, data?: Record<string, any>) {
   console.log("[Test]", message, "data:", data)
   statusEl.innerHTML = message
   if (data?.sessionId !== undefined) {
     sessionIdEl.innerHTML = data?.sessionId || "&mdash;"
+  }
+  if (data?.sessionToken !== undefined) {
+    sessionTokenEl.innerHTML = data?.sessionToken || "&mdash;"
   }
 }
 
@@ -16,7 +33,7 @@ const fileFeeds = oneSchemaFileFeeds({
   parentId: "oneschema-container",
   baseUrl: "http://embed.localschema.co:9450",
   userJwt:
-    "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiI4MDMyYWY0Yi1lMmQ5LTQwYWQtODE0Mi1lNjgwMTFkOTRkOWMiLCJ1c2VyX2lkIjoiPFVTRVJfSUQ-IiwiY3JlYXRlIjp7ImZpbGVfZmVlZCI6eyJuYW1lIjoiY3JtX3Rlc3RfMTcyNTQ5MTQ1ODA1OCIsInRlbXBsYXRlX2tleSI6ImNybV90ZXN0IiwiY3VzdG9tX21ldGFkYXRhIjp7fX19fQ.4izMP5MzlfxryMqpsJWW1o_fnpyMpG_EYLN12jObO-g",
+    "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiI1ZmU4MTRjNi0zNDVlLTRhZTctYTI3YS01MDNhMzU0MzY2MjYiLCJ1c2VyX2lkIjoiPFVTRVJfSUQ-IiwiY3JlYXRlIjp7InNlc3Npb24iOnsiZmlsZV9mZWVkX2lkIjo1Mjk3Nn19fQ.9hM5ZRDWTXBHD7g0sw6G_wcI61Gl503lquXfzr-1RnI",
   devMode: true,
   styles: {
     display: "flex",
@@ -30,7 +47,7 @@ const fileFeeds = oneSchemaFileFeeds({
 statusEl.innerHTML = "Loading in the background."
 
 document.getElementById("launch-button")!.onclick = () => {
-  fileFeeds.launch({ customizationOverrides: { backgroundPrimaryColor: "#FF00FF" } })
+  fileFeeds.launch( sessionToken ? { sessionToken } : {})
 }
 
 document.getElementById("hide-button")!.onclick = () => {
@@ -58,7 +75,7 @@ fileFeeds.on("init-succeeded", (data) => {
 })
 
 fileFeeds.on("destroyed", (data) => {
-  updateStatus("Destroyed.", { sessionId: "", ...data })
+  updateStatus("Destroyed.", { sessionId: "", sessionToken: "", ...data })
 })
 
 fileFeeds.on("hidden", (data) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8778,7 +8778,16 @@ streamroller@^3.1.5:
     debug "^4.3.4"
     fs-extra "^8.1.0"
 
-"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -8851,7 +8860,14 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -9591,7 +9607,16 @@ word-wrap@^1.2.3:
   resolved "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz"
   integrity sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
- expose `init` on the `init-success` event payload
- allow `init` via session token
- allow `resume` via session token
- add `sessionToken` query param on test