### PR TITLE
Add is_locked parameter to Template Overrides

### DIFF
--- a/packages/importer/src/config.ts
+++ b/packages/importer/src/config.ts
@@ -278,6 +278,7 @@ export type OneSchemaTemplateColumn = {
   is_custom: boolean
   is_required: boolean
   is_unique: boolean
+  is_locked: boolean
   letter_case: string
   min_char_limit: number
   max_char_limit: number


### PR DESCRIPTION
Added `is_locked` parameter to `OneSchemaTemplateColumn` - it was mentioned in the docs, but missing in the SDK