### PR TITLE
fix: use deep comparison for launch params to prevent spurious warning

### DIFF
--- a/packages/importer-react/src/OneSchemaImporter.tsx
+++ b/packages/importer-react/src/OneSchemaImporter.tsx
@@ -152,13 +152,24 @@ export default function OneSchemaImporter({
     }
   }, [importer, style])
 
+  const prevParamsRef = useRef<string>()
   useEffect(() => {
-    if (importer && importer._hasAttemptedLaunch && isOpen) {
+    const serializedParams = JSON.stringify(params)
+    const paramsChanged =
+      prevParamsRef.current !== undefined &&
+      prevParamsRef.current !== serializedParams
+    prevParamsRef.current = serializedParams
+
+    if (importer && importer._hasAttemptedLaunch && isOpen && paramsChanged) {
       console.warn(
         "The OneSchema importer has already launched. Updated launch params will not update the current import",
       )
     }
-  }, [params, importer, isOpen])
+    // NOTE: `params` is a new object reference on every render due to the
+    // `...rest` destructuring, so we track actual value changes via
+    // JSON.stringify instead of relying on referential equality.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [JSON.stringify(params), importer, isOpen])
 
   useEffect(() => {
     if (importer) {


### PR DESCRIPTION
## Summary

Fixes #137. The `OneSchemaImporter` React component logs a spurious "already launched" warning on every re-render after the importer has launched, even when no launch params have actually changed.

**Root cause:** `params` is created via `...rest` destructuring in the function signature, producing a new object reference on every render. The `useEffect` dependency array used this unstable reference, so the effect (and the warning) fired on every render cycle.

**Fix:** Replace referential equality with `JSON.stringify`-based deep comparison. A `useRef` tracks the previous serialized params, and the warning only fires when param values have genuinely changed. The dependency array uses `JSON.stringify(params)` so the effect itself is also skipped when values are stable.

## Review & Testing Checklist for Human

- [ ] Verify that `JSON.stringify` is adequate for all `OneSchemaLaunchParamOptions` fields — confirm none contain functions, `undefined` values that matter, or circular references that would break serialization
- [ ] Confirm the first-render guard (`prevParamsRef.current !== undefined`) correctly suppresses the warning on initial mount (we don't want a warning before params have ever "changed")
- [ ] **Manual test**: Render `<OneSchemaImporter>` with `isOpen={true}`, trigger a parent re-render (e.g. unrelated state change), and confirm the console warning no longer appears. Then actually change a launch param (e.g. `userJwt`) and confirm the warning _does_ appear.

### Notes

- No new dependencies added; `JSON.stringify` is used instead of a third-party deep-compare library.
- The `eslint-disable-next-line react-hooks/exhaustive-deps` is intentional: the dep array uses a computed `JSON.stringify(params)` expression rather than the raw `params` object, which the lint rule doesn't understand.

Link to Devin session: https://app.devin.ai/sessions/d9dbde3b76454bd6aa82a610c90d6776
Requested by: @behnam-oneschema