### PR TITLE
fix: catch errors thrown by onSuccess callback to prevent stuck loading state

### DIFF
--- a/packages/importer-react/src/OneSchemaImporter.tsx
+++ b/packages/importer-react/src/OneSchemaImporter.tsx
@@ -110,7 +110,27 @@ export default function OneSchemaImporter({
   useEffect(() => {
     if (importer) {
       importer.on("success", (data: any) => {
-        onSuccess?.(data)
+        try {
+          const result = onSuccess?.(data)
+          // Handle async onSuccess callbacks that return a rejected Promise.
+          if (result instanceof Promise) {
+            result.catch((e: unknown) => {
+              console.error("OneSchema: error in onSuccess handler", e)
+              onError?.({
+                message:
+                  e instanceof Error ? e.message : "Error in onSuccess handler",
+                severity: OneSchemaErrorSeverity.Error,
+              })
+            })
+          }
+        } catch (e) {
+          console.error("OneSchema: error in onSuccess handler", e)
+          onError?.({
+            message:
+              e instanceof Error ? e.message : "Error in onSuccess handler",
+            severity: OneSchemaErrorSeverity.Error,
+          })
+        }
         onRequestClose?.()
       })
 

--- a/packages/importer/src/importer.ts
+++ b/packages/importer/src/importer.ts
@@ -424,16 +424,28 @@ export class OneSchemaImporterClass extends EventEmitter {
       }
 
       case "complete": {
-        if (data.data) {
-          // for frontend pass through
-          this.emit("success", data.data)
-        } else {
-          // for webhook imports, eventId and responses are used
-          this.emit("success", {
-            eventId: data.eventId,
-            responses: data.responses,
+        try {
+          if (data.data) {
+            // for frontend pass through
+            this.emit("success", data.data)
+          } else {
+            // for webhook imports, eventId and responses are used
+            this.emit("success", {
+              eventId: data.eventId,
+              responses: data.responses,
+            })
+          }
+        } catch (e) {
+          // NOTE: Catch errors thrown by "success" event listeners so that
+          // cleanup (resume-token removal, autoClose) always runs.
+          console.error("OneSchema: error in success event listener", e)
+          this.emitErrorEvent({
+            message:
+              e instanceof Error ? e.message : "Error in success event listener",
+            severity: OneSchemaErrorSeverity.Error,
           })
         }
+
         if (this.#resumeTokenKey) {
           try {
             window.localStorage.removeItem(this.#resumeTokenKey)


### PR DESCRIPTION
## Summary

Fixes #136.

When an `onSuccess` callback throws (synchronously or via an async rejection), the importer gets stuck in a loading state because cleanup code never executes. This PR adds error handling at two layers:

1. **`packages/importer/src/importer.ts`** — Wraps `this.emit("success", ...)` in a try/catch inside the `"complete"` message handler. This ensures resume-token removal and `autoClose` always run regardless of listener errors. Caught errors are surfaced via the existing `error` event with `Error` severity (not `Fatal`, since the data import itself succeeded).

2. **`packages/importer-react/src/OneSchemaImporter.tsx`** — Wraps the `onSuccess?.(data)` call to catch both synchronous throws and asynchronous Promise rejections. Errors are forwarded to `onError`. `onRequestClose()` is now always called.

## Tasks

https://github.com/oneschema/sdk/issues/136

## Review & Testing Checklist for Human

- [ ] **Async error ordering**: For async `onSuccess` handlers, `onRequestClose` fires synchronously (immediately), while `onError` fires asynchronously (when the Promise rejects). Verify this ordering is acceptable for consumers — the importer will close before `onError` is called.
- [ ] **`onError` itself throwing**: If the consumer's `onError` handler throws, that error is not caught. Decide if this is acceptable or if it needs a guard too.
- [ ] **Scope limited to importer only**: The filefeeds package (`filefeeds.ts`, `OneSchemaFileFeeds.tsx`) has similar emit/callback patterns but is not patched here. Confirm this is the desired scope.
- [ ] **Manual test**: Use a React app with `onSuccess` that throws synchronously and one that returns a rejected Promise. Confirm the importer closes properly and `onError` is called in both cases.

### Notes

- The `onSuccess` prop is typed as `(data: any) => void`, but at runtime consumers commonly pass async functions. The fix captures the return value and checks `instanceof Promise` to handle this case.
- Error severity is `Error` (not `Fatal`) since the data import completed successfully on the backend — only the consumer's callback failed.

Link to Devin session: https://app.devin.ai/sessions/5f7e446f2a86441b8b4eb120916536af
Requested by: @behnam-oneschema