### PR TITLE
feat: show iframe immediately on launch and add loading indicator params

### DIFF
--- a/packages/importer-react/src/OneSchemaImporter.tsx
+++ b/packages/importer-react/src/OneSchemaImporter.tsx
@@ -36,6 +36,13 @@ export interface OneSchemaImporterBaseProps {
   style?: React.CSSProperties
 
   /**
+   * An optional React element to render as a loading indicator while the
+   * importer iframe initializes. Shown when the importer is open but not
+   * yet ready.
+   */
+  importerLoadingComponent?: React.ReactNode
+
+  /**
    * Handler for when the importer wants to close
    * should set isOpen prop to false
    */
@@ -82,6 +89,7 @@ export default function OneSchemaImporter({
   style,
   className,
   inline = true,
+  importerLoadingComponent,
   onRequestClose,
   onSuccess,
   onCancel,
@@ -90,6 +98,8 @@ export default function OneSchemaImporter({
   onLaunched,
   ...params
 }: OneSchemaImporterProps) {
+  const [isLoading, setIsLoading] = useState(false)
+
   const [importer] = useState(() => {
     const instance = oneschemaImporter({
       ...params,
@@ -131,6 +141,7 @@ export default function OneSchemaImporter({
       })
 
       importer.on("launched", (data: OneSchemaLaunchStatus) => {
+        setIsLoading(false)
         onLaunched?.(data)
       })
     }
@@ -163,8 +174,10 @@ export default function OneSchemaImporter({
   useEffect(() => {
     if (importer) {
       if (isOpen) {
+        setIsLoading(true)
         importer.launch(params)
       } else {
+        setIsLoading(false)
         importer.close()
       }
     }
@@ -183,9 +196,14 @@ export default function OneSchemaImporter({
   )
 
   if (inline) {
-    return <Iframe ref={setIframeRef} />
+    return (
+      <>
+        <Iframe ref={setIframeRef} />
+        {isLoading && importerLoadingComponent}
+      </>
+    )
   } else {
-    return null
+    return isLoading && importerLoadingComponent ? <>{importerLoadingComponent}</> : null
   }
 }
 

--- a/packages/importer/src/config.ts
+++ b/packages/importer/src/config.ts
@@ -564,6 +564,12 @@ export interface OneSchemaInitParams {
    * By default uses OneSchema's production instance
    */
   baseUrl?: string
+  /**
+   * An optional DOM element to display as a loading indicator while the
+   * importer iframe initializes. The SDK will show this element when
+   * launch() is called and hide it once the importer is ready.
+   */
+  importerLoadingElement?: HTMLElement
 }
 
 /**

--- a/packages/importer/src/importer.ts
+++ b/packages/importer/src/importer.ts
@@ -251,6 +251,7 @@ export class OneSchemaImporterClass extends EventEmitter {
     // state instead of staring at a blank screen while the session
     // initializes.
     this.#show()
+    this.#showLoading()
 
     const postInit = () => {
       this.#hasCancelled = false
@@ -315,6 +316,7 @@ export class OneSchemaImporterClass extends EventEmitter {
    */
   close(clean?: boolean) {
     this.#hide()
+    this.#hideLoading()
     if (this.iframe && OneSchemaImporterClass.#iframeIsLoaded) {
       this.#iframeEventEmit({ messageType: "close" })
     }
@@ -368,6 +370,20 @@ export class OneSchemaImporterClass extends EventEmitter {
     }
   }
 
+  #showLoading() {
+    const el = this.#params.importerLoadingElement
+    if (el) {
+      el.style.display = "initial"
+    }
+  }
+
+  #hideLoading() {
+    const el = this.#params.importerLoadingElement
+    if (el) {
+      el.style.display = "none"
+    }
+  }
+
   #iframeEventListener({ source, data }: MessageEvent) {
     if (source !== this.iframe?.contentWindow) {
       return
@@ -390,6 +406,7 @@ export class OneSchemaImporterClass extends EventEmitter {
 
       case "launched": {
         this.#hasLaunched = true
+        this.#hideLoading()
         let sessionToken = data.sessionToken
         const embedId = data.embedId
         if (this.#resumeTokenKey && sessionToken) {

--- a/packages/importer/src/importer.ts
+++ b/packages/importer/src/importer.ts
@@ -247,6 +247,11 @@ export class OneSchemaImporterClass extends EventEmitter {
   }
 
   _launch() {
+    // Show the iframe immediately so the user sees the embed's loading
+    // state instead of staring at a blank screen while the session
+    // initializes.
+    this.#show()
+
     const postInit = () => {
       this.#hasCancelled = false
       this._initWithRetry()


### PR DESCRIPTION
## Summary

Moves `this.#show()` from the `"launched"` event handler to the start of `_launch()`, so the iframe becomes visible immediately when `launch()` is called instead of after the full initialization round-trip completes.

Previously the iframe stayed `display: none` through the entire init lifecycle (iframe load → postMessage handshake → server-side session creation), leaving users staring at nothing for 1-3 seconds. Now the embed-launcher's own loading states (e.g. the `<Spin />` during session init) are visible during that wait.

Additionally, adds configurable loading indicator support so SDK consumers can provide their own loading UI:

- **Core SDK (`@oneschema/importer`)**: New `importerLoadingElement` param — accepts an `HTMLElement` that the SDK shows on `launch()` and hides on `"launched"` or `close()`.
- **React wrapper (`@oneschema/importer-react`)**: New `importerLoadingComponent` prop — accepts a `ReactNode` rendered while the importer is initializing (`isOpen` is true but `"launched"` hasn't fired yet).

Companion PR: oneschema/oneschema#12728 (shows a spinner in the embed-launcher's `Uninitialized` state for non-devMode, so the iframe isn't blank before the SDK's init message arrives).

## Review & Testing Checklist for Human

- [ ] **Deploy ordering**: The oneschema/oneschema companion change should deploy **before** this SDK is released. Without it, non-devMode consumers will see a blank white iframe flash in the `Uninitialized` state (the embed-launcher currently returns `null` there).
- [ ] **`launch-error` + devMode path**: When a `launch-error` fires in devMode, `#hideLoading()` is not called (only `#show()` is). Verify this is acceptable — the `importerLoadingElement` would remain visible alongside the error iframe in devMode.
- [ ] **Impact on existing SDK consumers**: Showing the iframe immediately is a behavioral change for all users. Customers who render their own loading overlay on top of the iframe position may now see the iframe's loading content alongside their overlay. Consider whether the early `#show()` should be behind an opt-in flag instead of the new default.
- [ ] **Visual layering of `importerLoadingComponent`**: In the React wrapper, the loading component renders as a sibling after the iframe (`<Iframe /> {isLoading && importerLoadingComponent}`). Consumers need to handle positioning/z-index themselves so it overlays correctly. Verify this is the right approach vs. wrapping in a positioned container.
- [ ] **Test in the sandbox**: Click "Preview in Sandbox" on a template page and verify the modal appears immediately with a loading spinner rather than a delayed pop-in. Test with both devMode and production-like configurations.
- [ ] **Test close-during-loading**: Call `close()` while the iframe is in the loading state (before `"launched"` fires) and verify the iframe and any loading indicator hide correctly.

### Notes

- The redundant `this.#show()` on the `"launched"` event handler (line 431) was intentionally left in place — it's harmless and keeps the handler self-contained.
- `#showLoading()` / `#hideLoading()` toggle `display` between `"initial"` and `"none"`. If a consumer's loading element originally uses a different display value (e.g. `flex`), it will be reset to `initial` (i.e. `inline`). This mirrors how `#show()` / `#hide()` manage the iframe.
- The React wrapper's `isLoading` state is set to `false` both when `"launched"` fires (success or failure) and when `isOpen` becomes false, ensuring no stale loading UI.

Link to Devin session: https://app.devin.ai/sessions/0ce00f0ea16344e48cae392f4bb61723
Requested by: @matthewoey