### PR TITLE
feat: add MCP server package for flowgraph management

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "packages/filefeeds-react",
     "packages/importer-vue",
     "packages/importer-angular",
-    "packages/importer-angular/projects/oneschema"
+    "packages/importer-angular/projects/oneschema",
+    "packages/mcp-server"
   ],
   "scripts": {
     "clean": "rm -rf node_modules && yarn workspaces run clean",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@oneschema/mcp-server",
+  "private": false,
+  "version": "0.1.0",
+  "description": "MCP server for OneSchema Multi FileFeed (workflow) and flowgraph management",
+  "author": "OneSchema",
+  "license": "MIT",
+  "type": "module",
+  "bin": {
+    "oneschema-mcp-server": "./dist/index.js"
+  },
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "homepage": "https://www.oneschema.co/",
+  "bugs": "https://github.com/oneschema/sdk/issues",
+  "repository": {
+    "type": "git",
+    "url": "github:oneschema/sdk",
+    "directory": "packages/mcp-server"
+  },
+  "scripts": {
+    "build": "tsc",
+    "clean": "npx --yes rimraf dist",
+    "lint": "tsc --noEmit",
+    "start": "node dist/index.js",
+    "inspect": "npx @modelcontextprotocol/inspector node dist/index.js",
+    "test": "node --test dist/__tests__/*.test.js"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.12.1",
+    "zod": "^3.24.4"
+  },
+  "devDependencies": {
+    "@types/node": "^22.15.2",
+    "typescript": "^5.8.3"
+  }
+}

--- a/packages/mcp-server/src/__tests__/server.test.ts
+++ b/packages/mcp-server/src/__tests__/server.test.ts
@@ -1,0 +1,463 @@
+/**
+ * Integration tests for the MCP server protocol layer.
+ *
+ * Tests resource listing/reading and prompt listing/getting by
+ * connecting a Client to the Server via in-memory transports.
+ */
+
+import { describe, it, before, after } from "node:test"
+import assert from "node:assert/strict"
+import http from "node:http"
+import { Client } from "@modelcontextprotocol/sdk/client/index.js"
+import { Server } from "@modelcontextprotocol/sdk/server/index.js"
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js"
+import {
+  CallToolRequestSchema,
+  GetPromptRequestSchema,
+  ListPromptsRequestSchema,
+  ListResourcesRequestSchema,
+  ListResourceTemplatesRequestSchema,
+  ListToolsRequestSchema,
+  ReadResourceRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js"
+import { OneSchemaClient } from "../api-client.js"
+import { prompts } from "../prompts.js"
+import {
+  resourceTemplates,
+  staticResources,
+} from "../resources.js"
+import { handleToolCall, toolDefinitions } from "../tools.js"
+
+// -- Mock server for OneSchema API -------------------------------------------
+
+function createMockApiServer(): http.Server {
+  return http.createServer((req, res) => {
+    const url = new URL(req.url ?? "/", "http://localhost")
+    const pathname = url.pathname
+
+    if (
+      req.method === "GET" &&
+      pathname === "/v0/multi-file-feeds"
+    ) {
+      res.writeHead(200, { "Content-Type": "application/json" })
+      res.end(
+        JSON.stringify([
+          { id: 1, name: "Workflow A", workspace_id: null },
+        ]),
+      )
+      return
+    }
+
+    if (
+      req.method === "GET" &&
+      /^\/v0\/multi-file-feeds\/\d+$/.test(pathname)
+    ) {
+      res.writeHead(200, { "Content-Type": "application/json" })
+      res.end(
+        JSON.stringify({
+          id: 1,
+          name: "Workflow A",
+          workspace_id: null,
+          custom_metadata: {},
+          templates: [],
+          source: [],
+          destination: [],
+          event_webhooks: [],
+          post_validation_transform_key: null,
+        }),
+      )
+      return
+    }
+
+    if (
+      req.method === "GET" &&
+      /^\/v0\/multi-file-feeds\/\d+\/flowgraph$/.test(pathname)
+    ) {
+      res.writeHead(200, { "Content-Type": "application/json" })
+      res.end(
+        JSON.stringify({
+          version: 0,
+          exported_at: "2025-01-01T00:00:00Z",
+          source_workflow_name: "Workflow A",
+          flowgraph: {
+            nodes: [
+              {
+                node_key: "src",
+                type: "source",
+                config: {},
+              },
+            ],
+            edges: [],
+          },
+        }),
+      )
+      return
+    }
+
+    res.writeHead(404, { "Content-Type": "application/json" })
+    res.end(JSON.stringify({ error: "Not found" }))
+  })
+}
+
+// -- Helper to match URI templates -------------------------------------------
+
+function matchUriTemplate(
+  template: string,
+  uri: string,
+): Record<string, string> | null {
+  const paramNames: string[] = []
+  const regexStr = template.replace(
+    /\{([^}]+)\}/g,
+    (_match, paramName: string) => {
+      paramNames.push(paramName)
+      return "([^/]+)"
+    },
+  )
+  const match = new RegExp(`^${regexStr}$`).exec(uri)
+  if (!match) return null
+  const params: Record<string, string> = {}
+  paramNames.forEach((name, i) => {
+    params[name] = match[i + 1]
+  })
+  return params
+}
+
+// -- Test suite --------------------------------------------------------------
+
+describe("MCP server protocol", () => {
+  let mcpClient: Client
+  let mcpServer: Server
+  let apiClient: OneSchemaClient
+  let mockApiServer: http.Server
+
+  before(async () => {
+    // Start mock API server
+    mockApiServer = createMockApiServer()
+    await new Promise<void>((resolve) => {
+      mockApiServer.listen(0, "127.0.0.1", () => resolve())
+    })
+    const addr = mockApiServer.address()
+    let baseUrl = "http://127.0.0.1"
+    if (typeof addr === "object" && addr !== null) {
+      baseUrl = `http://127.0.0.1:${addr.port}`
+    }
+    apiClient = new OneSchemaClient({
+      baseUrl,
+      apiKey: "test-key",
+    })
+
+    // Create MCP server with handlers
+    mcpServer = new Server(
+      { name: "oneschema-test", version: "0.1.0" },
+      {
+        capabilities: {
+          tools: {},
+          resources: {},
+          prompts: {},
+        },
+      },
+    )
+
+    // Register handlers (same as index.ts)
+    mcpServer.setRequestHandler(
+      ListToolsRequestSchema,
+      async () => ({
+        tools: toolDefinitions,
+      }),
+    )
+
+    mcpServer.setRequestHandler(
+      CallToolRequestSchema,
+      async (request) => {
+        const { name, arguments: args } = request.params
+        return handleToolCall(apiClient, name, args ?? {})
+      },
+    )
+
+    mcpServer.setRequestHandler(
+      ListResourcesRequestSchema,
+      async () => ({
+        resources: staticResources.map((r) => ({
+          uri: r.uri,
+          name: r.name,
+          description: r.description,
+          mimeType: r.mimeType,
+        })),
+      }),
+    )
+
+    mcpServer.setRequestHandler(
+      ListResourceTemplatesRequestSchema,
+      async () => ({
+        resourceTemplates: resourceTemplates.map((t) => ({
+          uriTemplate: t.uriTemplate,
+          name: t.name,
+          description: t.description,
+          mimeType: t.mimeType,
+        })),
+      }),
+    )
+
+    mcpServer.setRequestHandler(
+      ReadResourceRequestSchema,
+      async (request) => {
+        const uri = request.params.uri
+
+        for (const resource of staticResources) {
+          if (uri === resource.uri) {
+            const text = await resource.handler(apiClient, {})
+            return {
+              contents: [
+                {
+                  uri: resource.uri,
+                  mimeType: resource.mimeType,
+                  text,
+                },
+              ],
+            }
+          }
+        }
+
+        for (const template of resourceTemplates) {
+          const params = matchUriTemplate(
+            template.uriTemplate,
+            uri,
+          )
+          if (params) {
+            const text = await template.handler(
+              apiClient,
+              params,
+            )
+            return {
+              contents: [
+                { uri, mimeType: template.mimeType, text },
+              ],
+            }
+          }
+        }
+
+        throw new Error(`Resource not found: ${uri}`)
+      },
+    )
+
+    mcpServer.setRequestHandler(
+      ListPromptsRequestSchema,
+      async () => ({
+        prompts: prompts.map((p) => ({
+          name: p.name,
+          description: p.description,
+          arguments: p.arguments,
+        })),
+      }),
+    )
+
+    mcpServer.setRequestHandler(
+      GetPromptRequestSchema,
+      async (request) => {
+        const { name, arguments: args } = request.params
+        const prompt = prompts.find((p) => p.name === name)
+        if (!prompt) throw new Error(`Prompt not found: ${name}`)
+        const stringArgs: Record<string, string> = {}
+        if (args) {
+          for (const [key, value] of Object.entries(args)) {
+            if (value !== undefined)
+              stringArgs[key] = String(value)
+          }
+        }
+        return { messages: prompt.handler(stringArgs) }
+      },
+    )
+
+    // Connect via in-memory transport
+    const [clientTransport, serverTransport] =
+      InMemoryTransport.createLinkedPair()
+
+    mcpClient = new Client({
+      name: "test-client",
+      version: "1.0.0",
+    })
+
+    await Promise.all([
+      mcpClient.connect(clientTransport),
+      mcpServer.connect(serverTransport),
+    ])
+  })
+
+  after(async () => {
+    await mcpClient.close()
+    await mcpServer.close()
+    await new Promise<void>((resolve) => {
+      mockApiServer.close(() => resolve())
+    })
+  })
+
+  // -- Tools -----------------------------------------------------------------
+
+  describe("tools", () => {
+    it("lists all 10 tools", async () => {
+      const result = await mcpClient.listTools()
+      assert.equal(result.tools.length, 10)
+      const names = result.tools.map((t) => t.name).sort()
+      assert.deepEqual(names, [
+        "create_simple_workflow",
+        "create_template",
+        "create_workflow_from_flowgraph",
+        "delete_workflow",
+        "duplicate_workflow",
+        "export_flowgraph",
+        "get_template",
+        "get_workflow",
+        "list_workflows",
+        "update_workflow",
+      ])
+    })
+
+    it("calls list_workflows via MCP protocol", async () => {
+      const result = await mcpClient.callTool({
+        name: "list_workflows",
+        arguments: {},
+      })
+      assert.equal(result.isError, undefined)
+      const content = result.content as { type: string; text: string }[]
+      const data = JSON.parse(content[0].text)
+      assert.ok(Array.isArray(data))
+    })
+
+    it("calls get_workflow via MCP protocol", async () => {
+      const result = await mcpClient.callTool({
+        name: "get_workflow",
+        arguments: { workflow_id: 1 },
+      })
+      assert.equal(result.isError, undefined)
+      const content = result.content as { type: string; text: string }[]
+      const text = content[0].text
+      const data = JSON.parse(text)
+      assert.equal(data.id, 1)
+    })
+  })
+
+  // -- Resources -------------------------------------------------------------
+
+  describe("resources", () => {
+    it("lists static resources", async () => {
+      const result = await mcpClient.listResources()
+      assert.ok(result.resources.length >= 2)
+      const uris = result.resources.map((r) => r.uri)
+      assert.ok(uris.includes("oneschema://node-types"))
+      assert.ok(uris.includes("oneschema://workflows"))
+    })
+
+    it("lists resource templates", async () => {
+      const result = await mcpClient.listResourceTemplates()
+      assert.ok(result.resourceTemplates.length >= 2)
+      const templates = result.resourceTemplates.map(
+        (t) => t.uriTemplate,
+      )
+      assert.ok(
+        templates.includes(
+          "oneschema://workflows/{workflow_id}",
+        ),
+      )
+      assert.ok(
+        templates.includes(
+          "oneschema://workflows/{workflow_id}/flowgraph",
+        ),
+      )
+    })
+
+    it("reads node-types resource", async () => {
+      const result = await mcpClient.readResource({
+        uri: "oneschema://node-types",
+      })
+      assert.ok(result.contents.length > 0)
+      const entry = result.contents[0] as { uri: string; text: string; mimeType?: string }
+      const data = JSON.parse(entry.text)
+      assert.ok(Array.isArray(data))
+      assert.ok(data.length === 20)
+      assert.ok(
+        data.some(
+          (n: { type: string }) => n.type === "source",
+        ),
+      )
+    })
+
+    it("reads workflows resource", async () => {
+      const result = await mcpClient.readResource({
+        uri: "oneschema://workflows",
+      })
+      assert.ok(result.contents.length > 0)
+      const entry = result.contents[0] as { uri: string; text: string; mimeType?: string }
+      const data = JSON.parse(entry.text)
+      assert.ok(Array.isArray(data))
+    })
+
+    it("reads a specific workflow resource", async () => {
+      const result = await mcpClient.readResource({
+        uri: "oneschema://workflows/1",
+      })
+      assert.ok(result.contents.length > 0)
+      const entry = result.contents[0] as { uri: string; text: string; mimeType?: string }
+      const data = JSON.parse(entry.text)
+      assert.equal(data.id, 1)
+    })
+
+    it("reads a workflow flowgraph resource", async () => {
+      const result = await mcpClient.readResource({
+        uri: "oneschema://workflows/1/flowgraph",
+      })
+      assert.ok(result.contents.length > 0)
+      const entry = result.contents[0] as { uri: string; text: string; mimeType?: string }
+      const data = JSON.parse(entry.text)
+      assert.equal(data.version, 0)
+      assert.ok(data.flowgraph)
+    })
+  })
+
+  // -- Prompts ---------------------------------------------------------------
+
+  describe("prompts", () => {
+    it("lists all prompts", async () => {
+      const result = await mcpClient.listPrompts()
+      assert.equal(result.prompts.length, 2)
+      const names = result.prompts.map((p) => p.name).sort()
+      assert.deepEqual(names, [
+        "create_simple_workflow",
+        "describe_workflow",
+      ])
+    })
+
+    it("gets create_simple_workflow prompt", async () => {
+      const result = await mcpClient.getPrompt({
+        name: "create_simple_workflow",
+        arguments: {
+          workflow_name: "Invoice Processing",
+          template_key: "invoices",
+        },
+      })
+      assert.ok(result.messages.length > 0)
+      const text = (
+        result.messages[0].content as {
+          type: "text"
+          text: string
+        }
+      ).text
+      assert.ok(text.includes("Invoice Processing"))
+      assert.ok(text.includes("invoices"))
+    })
+
+    it("gets describe_workflow prompt", async () => {
+      const result = await mcpClient.getPrompt({
+        name: "describe_workflow",
+        arguments: { workflow_id: "42" },
+      })
+      assert.ok(result.messages.length > 0)
+      const text = (
+        result.messages[0].content as {
+          type: "text"
+          text: string
+        }
+      ).text
+      assert.ok(text.includes("42"))
+    })
+  })
+})

--- a/packages/mcp-server/src/__tests__/tools.test.ts
+++ b/packages/mcp-server/src/__tests__/tools.test.ts
@@ -1,0 +1,468 @@
+/**
+ * Integration tests for MCP server tools.
+ *
+ * Uses a lightweight HTTP mock server to simulate the OneSchema API,
+ * then exercises each tool via the handleToolCall dispatch function.
+ *
+ * To run against a real API instead of the mock, set:
+ *   ONESCHEMA_API_KEY=<key> ONESCHEMA_API_URL=<url> node --test dist/__tests__/tools.test.js
+ */
+
+import { describe, it, before, after } from "node:test"
+import assert from "node:assert/strict"
+import http from "node:http"
+import { OneSchemaClient } from "../api-client.js"
+import { handleToolCall } from "../tools.js"
+
+// -- Mock server setup -------------------------------------------------------
+
+interface MockRoute {
+  method: string
+  path: string | RegExp
+  status: number
+  body: unknown
+}
+
+const MOCK_ROUTES: MockRoute[] = [
+  // list_workflows
+  {
+    method: "GET",
+    path: "/v0/multi-file-feeds",
+    status: 200,
+    body: [
+      { id: 1, name: "Test Workflow", workspace_id: null },
+      { id: 2, name: "Another Workflow", workspace_id: null },
+    ],
+  },
+  // get_workflow
+  {
+    method: "GET",
+    path: /^\/v0\/multi-file-feeds\/(\d+)$/,
+    status: 200,
+    body: {
+      id: 1,
+      name: "Test Workflow",
+      workspace_id: null,
+      custom_metadata: {},
+      templates: [
+        { name: "Invoice", description: null, key: "invoices" },
+      ],
+      source: [],
+      destination: [],
+      event_webhooks: [],
+      post_validation_transform_key: null,
+    },
+  },
+  // export_flowgraph
+  {
+    method: "GET",
+    path: /^\/v0\/multi-file-feeds\/(\d+)\/flowgraph$/,
+    status: 200,
+    body: {
+      version: 0,
+      exported_at: "2025-01-01T00:00:00Z",
+      source_workflow_name: "Test Workflow",
+      templates: [
+        { template_key: "invoices", is_required: true },
+      ],
+      flowgraph: {
+        nodes: [
+          {
+            node_key: "source-node",
+            type: "source",
+            config: {},
+          },
+          {
+            node_key: "import-node",
+            type: "import",
+            config: {},
+          },
+          {
+            node_key: "help-text-node",
+            type: "help-text",
+            config: {},
+          },
+        ],
+        edges: [
+          {
+            from_node_key: "source-node",
+            to_node_key: "import-node",
+          },
+        ],
+      },
+    },
+  },
+  // create_workflow_from_flowgraph (import-from-json)
+  {
+    method: "POST",
+    path: "/v0/multi-file-feeds/import-from-json",
+    status: 200,
+    body: {
+      id: 10,
+      name: "Created Workflow",
+      workspace_id: null,
+      custom_metadata: {},
+      templates: [],
+      source: [],
+      destination: [],
+      event_webhooks: [],
+      post_validation_transform_key: null,
+    },
+  },
+  // duplicate_workflow
+  {
+    method: "POST",
+    path: /^\/v0\/multi-file-feeds\/(\d+)\/duplicate$/,
+    status: 200,
+    body: {
+      id: 11,
+      name: "Duplicated Workflow",
+      workspace_id: null,
+      custom_metadata: {},
+      templates: [],
+      source: [],
+      destination: [],
+      event_webhooks: [],
+      post_validation_transform_key: null,
+    },
+  },
+  // update_workflow
+  {
+    method: "PATCH",
+    path: /^\/v0\/multi-file-feeds\/(\d+)$/,
+    status: 200,
+    body: {
+      id: 1,
+      name: "Updated Workflow",
+      workspace_id: null,
+      custom_metadata: {},
+      templates: [],
+      source: [],
+      destination: [],
+      event_webhooks: [],
+      post_validation_transform_key: null,
+    },
+  },
+  // delete_workflow
+  {
+    method: "DELETE",
+    path: /^\/v0\/multi-file-feeds\/(\d+)$/,
+    status: 200,
+    body: { success: true },
+  },
+  // get_template
+  {
+    method: "GET",
+    path: /^\/templates\/export\/.+$/,
+    status: 200,
+    body: {
+      name: "Invoices",
+      template_key: "invoices",
+      columns: [
+        { label: "Invoice Number", key: "invoice_number" },
+        { label: "Amount", key: "amount", data_type: "NUMBER" },
+      ],
+    },
+  },
+  // create_template
+  {
+    method: "POST",
+    path: "/templates/import",
+    status: 200,
+    body: { id: 42 },
+  },
+]
+
+function createMockServer(): http.Server {
+  return http.createServer((req, res) => {
+    const url = new URL(req.url ?? "/", `http://localhost`)
+    const pathname = url.pathname
+    const method = req.method ?? "GET"
+
+    for (const route of MOCK_ROUTES) {
+      const pathMatch =
+        typeof route.path === "string"
+          ? pathname === route.path
+          : route.path.test(pathname)
+
+      if (method === route.method && pathMatch) {
+        res.writeHead(route.status, {
+          "Content-Type": "application/json",
+        })
+        res.end(JSON.stringify(route.body))
+        return
+      }
+    }
+
+    // 404 for unmatched routes
+    res.writeHead(404, { "Content-Type": "application/json" })
+    res.end(
+      JSON.stringify({
+        error: `Not found: ${method} ${pathname}`,
+      }),
+    )
+  })
+}
+
+// -- Test setup --------------------------------------------------------------
+
+describe("MCP tools integration", () => {
+  let client: OneSchemaClient
+  let mockServer: http.Server
+  let baseUrl: string
+
+  before(async () => {
+    // Use real API if env vars are set, otherwise use mock
+    if (
+      process.env.ONESCHEMA_API_KEY &&
+      process.env.ONESCHEMA_API_URL
+    ) {
+      client = new OneSchemaClient({
+        baseUrl: process.env.ONESCHEMA_API_URL,
+        apiKey: process.env.ONESCHEMA_API_KEY,
+      })
+    } else {
+      mockServer = createMockServer()
+      await new Promise<void>((resolve) => {
+        mockServer.listen(0, "127.0.0.1", () => resolve())
+      })
+      const addr = mockServer.address()
+      if (typeof addr === "object" && addr !== null) {
+        baseUrl = `http://127.0.0.1:${addr.port}`
+      }
+      client = new OneSchemaClient({
+        baseUrl,
+        apiKey: "test-api-key",
+      })
+    }
+  })
+
+  after(async () => {
+    if (mockServer) {
+      await new Promise<void>((resolve) => {
+        mockServer.close(() => resolve())
+      })
+    }
+  })
+
+  // -- Tool tests ------------------------------------------------------------
+
+  it("list_workflows returns an array", async () => {
+    const result = await handleToolCall(
+      client,
+      "list_workflows",
+      {},
+    )
+    assert.equal(result.isError, undefined)
+    assert.equal(result.content.length, 1)
+    const data = JSON.parse(
+      (result.content[0] as { type: "text"; text: string }).text,
+    )
+    assert.ok(Array.isArray(data))
+    assert.ok(data.length > 0)
+    assert.ok(typeof data[0].id === "number")
+    assert.ok(typeof data[0].name === "string")
+  })
+
+  it("list_workflows supports folder_id filter", async () => {
+    const result = await handleToolCall(
+      client,
+      "list_workflows",
+      { folder_id: 1 },
+    )
+    assert.equal(result.isError, undefined)
+  })
+
+  it("get_workflow returns workflow details", async () => {
+    const result = await handleToolCall(client, "get_workflow", {
+      workflow_id: 1,
+    })
+    assert.equal(result.isError, undefined)
+    const data = JSON.parse(
+      (result.content[0] as { type: "text"; text: string }).text,
+    )
+    assert.ok(typeof data.id === "number")
+    assert.ok(typeof data.name === "string")
+    assert.ok(Array.isArray(data.templates))
+  })
+
+  it("export_flowgraph returns flowgraph JSON", async () => {
+    const result = await handleToolCall(
+      client,
+      "export_flowgraph",
+      { workflow_id: 1 },
+    )
+    assert.equal(result.isError, undefined)
+    const data = JSON.parse(
+      (result.content[0] as { type: "text"; text: string }).text,
+    )
+    assert.equal(data.version, 0)
+    assert.ok(data.flowgraph)
+    assert.ok(Array.isArray(data.flowgraph.nodes))
+    assert.ok(Array.isArray(data.flowgraph.edges))
+  })
+
+  it("create_workflow_from_flowgraph creates a workflow", async () => {
+    const result = await handleToolCall(
+      client,
+      "create_workflow_from_flowgraph",
+      {
+        name: "Test Created Workflow",
+        flowgraph: {
+          version: 0,
+          exported_at: new Date().toISOString(),
+          source_workflow_name: "Test Created Workflow",
+          flowgraph: {
+            nodes: [
+              {
+                node_key: "source-node",
+                type: "source",
+                config: {},
+              },
+              {
+                node_key: "import-node",
+                type: "import",
+                config: {},
+              },
+              {
+                node_key: "help-text-node",
+                type: "help-text",
+                config: {},
+              },
+            ],
+            edges: [
+              {
+                from_node_key: "source-node",
+                to_node_key: "import-node",
+              },
+            ],
+          },
+        },
+      },
+    )
+    assert.equal(result.isError, undefined)
+    const data = JSON.parse(
+      (result.content[0] as { type: "text"; text: string }).text,
+    )
+    assert.ok(typeof data.id === "number")
+  })
+
+  it("create_simple_workflow generates flowgraph and creates workflow", async () => {
+    const result = await handleToolCall(
+      client,
+      "create_simple_workflow",
+      {
+        name: "Simple Test Workflow",
+        template_key: "invoices",
+      },
+    )
+    assert.equal(result.isError, undefined)
+    const data = JSON.parse(
+      (result.content[0] as { type: "text"; text: string }).text,
+    )
+    assert.ok(typeof data.id === "number")
+  })
+
+  it("create_simple_workflow respects is_template_required", async () => {
+    const result = await handleToolCall(
+      client,
+      "create_simple_workflow",
+      {
+        name: "Optional Template Workflow",
+        template_key: "invoices",
+        is_template_required: false,
+      },
+    )
+    assert.equal(result.isError, undefined)
+  })
+
+  it("duplicate_workflow duplicates a workflow", async () => {
+    const result = await handleToolCall(
+      client,
+      "duplicate_workflow",
+      { workflow_id: 1, name: "Duplicated" },
+    )
+    assert.equal(result.isError, undefined)
+    const data = JSON.parse(
+      (result.content[0] as { type: "text"; text: string }).text,
+    )
+    assert.ok(typeof data.id === "number")
+  })
+
+  it("update_workflow updates metadata", async () => {
+    const result = await handleToolCall(
+      client,
+      "update_workflow",
+      { workflow_id: 1, name: "Updated Name" },
+    )
+    assert.equal(result.isError, undefined)
+    const data = JSON.parse(
+      (result.content[0] as { type: "text"; text: string }).text,
+    )
+    assert.ok(typeof data.id === "number")
+  })
+
+  it("delete_workflow deletes a workflow", async () => {
+    const result = await handleToolCall(
+      client,
+      "delete_workflow",
+      { workflow_id: 1 },
+    )
+    assert.equal(result.isError, undefined)
+    const data = JSON.parse(
+      (result.content[0] as { type: "text"; text: string }).text,
+    )
+    assert.ok(data.success === true)
+  })
+
+  it("get_template exports a template", async () => {
+    const result = await handleToolCall(client, "get_template", {
+      template_key: "invoices",
+    })
+    assert.equal(result.isError, undefined)
+    const data = JSON.parse(
+      (result.content[0] as { type: "text"; text: string }).text,
+    )
+    assert.ok(typeof data.name === "string")
+    assert.ok(typeof data.template_key === "string")
+    assert.ok(Array.isArray(data.columns))
+  })
+
+  it("create_template creates a template", async () => {
+    const result = await handleToolCall(
+      client,
+      "create_template",
+      {
+        name: "Test Template",
+        template_key: "test_template",
+        columns: [
+          { label: "Name", key: "name" },
+          {
+            label: "Email",
+            key: "email",
+            data_type: "EMAIL",
+            is_required: true,
+          },
+        ],
+      },
+    )
+    assert.equal(result.isError, undefined)
+    const data = JSON.parse(
+      (result.content[0] as { type: "text"; text: string }).text,
+    )
+    assert.ok(typeof data.id === "number")
+  })
+
+  it("unknown tool returns an error", async () => {
+    const result = await handleToolCall(
+      client,
+      "nonexistent_tool",
+      {},
+    )
+    assert.equal(result.isError, true)
+    const text = (
+      result.content[0] as { type: "text"; text: string }
+    ).text
+    assert.ok(text.includes("Unknown tool"))
+  })
+})

--- a/packages/mcp-server/src/api-client.ts
+++ b/packages/mcp-server/src/api-client.ts
@@ -1,0 +1,175 @@
+/**
+ * HTTP client for the OneSchema external API.
+ *
+ * Wraps fetch calls with authentication, error handling, and JSON parsing.
+ * All methods throw {@link OneSchemaApiError} on non-2xx responses.
+ */
+
+import type {
+  FlowgraphExport,
+  OneSchemaApiError,
+  TemplateExport,
+  Workflow,
+  WorkflowSummary,
+} from "./types.js"
+
+export class OneSchemaClient {
+  private readonly baseUrl: string
+  private readonly apiKey: string
+
+  constructor(opts: { baseUrl: string; apiKey: string }) {
+    this.baseUrl = opts.baseUrl.replace(/\/+$/, "")
+    this.apiKey = opts.apiKey
+  }
+
+  // -- Workflows -------------------------------------------------------------
+
+  async listWorkflows(folderId?: number): Promise<WorkflowSummary[]> {
+    const params = new URLSearchParams()
+    if (folderId !== undefined) {
+      params.set("folder_id", String(folderId))
+    }
+    const qs = params.toString()
+    const url = `/v0/multi-file-feeds${qs ? `?${qs}` : ""}`
+    return this.get<WorkflowSummary[]>(url)
+  }
+
+  async getWorkflow(workflowId: number): Promise<Workflow> {
+    return this.get<Workflow>(`/v0/multi-file-feeds/${workflowId}`)
+  }
+
+  async duplicateWorkflow(
+    workflowId: number,
+    name: string,
+  ): Promise<Workflow> {
+    return this.post<Workflow>(
+      `/v0/multi-file-feeds/${workflowId}/duplicate`,
+      { name },
+    )
+  }
+
+  async updateWorkflow(
+    workflowId: number,
+    updates: {
+      name?: string
+      folder_id?: number
+      source?: Record<string, unknown> | null
+      destination?: Record<string, unknown> | null
+    },
+  ): Promise<Workflow> {
+    return this.patch<Workflow>(
+      `/v0/multi-file-feeds/${workflowId}`,
+      updates,
+    )
+  }
+
+  async deleteWorkflow(
+    workflowId: number,
+  ): Promise<{ success: boolean }> {
+    return this.del<{ success: boolean }>(
+      `/v0/multi-file-feeds/${workflowId}`,
+    )
+  }
+
+  // -- Flowgraphs ------------------------------------------------------------
+
+  async exportFlowgraph(workflowId: number): Promise<FlowgraphExport> {
+    return this.get<FlowgraphExport>(
+      `/v0/multi-file-feeds/${workflowId}/flowgraph`,
+    )
+  }
+
+  async createWorkflowFromFlowgraph(params: {
+    name: string
+    folder_id?: number
+    flowgraph: FlowgraphExport
+  }): Promise<Workflow> {
+    const body: Record<string, unknown> = {
+      name: params.name,
+      ...params.flowgraph,
+    }
+    if (params.folder_id !== undefined) {
+      body.folder_id = params.folder_id
+    }
+    return this.post<Workflow>(
+      "/v0/multi-file-feeds/import-from-json",
+      body,
+    )
+  }
+
+  // -- Templates -------------------------------------------------------------
+
+  async getTemplate(templateKey: string): Promise<TemplateExport> {
+    return this.get<TemplateExport>(
+      `/templates/export/${encodeURIComponent(templateKey)}`,
+    )
+  }
+
+  async createTemplate(
+    template: TemplateExport,
+  ): Promise<{ id: number }> {
+    return this.post<{ id: number }>("/templates/import", template)
+  }
+
+  // -- HTTP helpers ----------------------------------------------------------
+
+  private async get<T>(path: string): Promise<T> {
+    return this.request<T>("GET", path)
+  }
+
+  private async post<T>(
+    path: string,
+    body: unknown,
+  ): Promise<T> {
+    return this.request<T>("POST", path, body)
+  }
+
+  private async patch<T>(
+    path: string,
+    body: unknown,
+  ): Promise<T> {
+    return this.request<T>("PATCH", path, body)
+  }
+
+  private async del<T>(path: string): Promise<T> {
+    return this.request<T>("DELETE", path)
+  }
+
+  private async request<T>(
+    method: string,
+    path: string,
+    body?: unknown,
+  ): Promise<T> {
+    const url = `${this.baseUrl}${path}`
+    const headers: Record<string, string> = {
+      "X-Api-Key": this.apiKey,
+      Accept: "application/json",
+    }
+    if (body !== undefined) {
+      headers["Content-Type"] = "application/json"
+    }
+
+    const res = await fetch(url, {
+      method,
+      headers,
+      body: body !== undefined ? JSON.stringify(body) : undefined,
+    })
+
+    if (!res.ok) {
+      let details: unknown
+      try {
+        details = await res.json()
+      } catch {
+        details = await res.text().catch(() => undefined)
+      }
+      const err: OneSchemaApiError = {
+        status: res.status,
+        message: `OneSchema API error: ${res.status} ${res.statusText}`,
+        details,
+      }
+      throw err
+    }
+
+    return (await res.json()) as T
+  }
+}

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -1,0 +1,220 @@
+#!/usr/bin/env node
+
+/**
+ * OneSchema MCP Server
+ *
+ * Exposes OneSchema Multi FileFeed (workflow) and flowgraph management
+ * as MCP tools, resources, and prompts for AI assistants.
+ *
+ * Configuration via environment variables:
+ *   ONESCHEMA_API_KEY  — Required. Your OneSchema API key.
+ *   ONESCHEMA_API_URL  — Optional. Defaults to https://api.oneschema.co
+ */
+
+import { Server } from "@modelcontextprotocol/sdk/server/index.js"
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
+import {
+  CallToolRequestSchema,
+  GetPromptRequestSchema,
+  ListPromptsRequestSchema,
+  ListResourcesRequestSchema,
+  ListResourceTemplatesRequestSchema,
+  ListToolsRequestSchema,
+  ReadResourceRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js"
+import { OneSchemaClient } from "./api-client.js"
+import { prompts } from "./prompts.js"
+import {
+  resourceTemplates,
+  staticResources,
+} from "./resources.js"
+import { handleToolCall, toolDefinitions } from "./tools.js"
+
+// -- Configuration -----------------------------------------------------------
+
+const API_KEY = process.env.ONESCHEMA_API_KEY
+const API_URL =
+  process.env.ONESCHEMA_API_URL ?? "https://api.oneschema.co"
+
+if (!API_KEY) {
+  console.error(
+    "Error: ONESCHEMA_API_KEY environment variable is required.",
+  )
+  process.exit(1)
+}
+
+// -- Initialize client and server --------------------------------------------
+
+const client = new OneSchemaClient({
+  baseUrl: API_URL,
+  apiKey: API_KEY,
+})
+
+const server = new Server(
+  { name: "oneschema", version: "0.1.0" },
+  {
+    capabilities: {
+      tools: {},
+      resources: {},
+      prompts: {},
+    },
+  },
+)
+
+// -- Tools -------------------------------------------------------------------
+
+server.setRequestHandler(ListToolsRequestSchema, async () => ({
+  tools: toolDefinitions,
+}))
+
+server.setRequestHandler(
+  CallToolRequestSchema,
+  async (request) => {
+    const { name, arguments: args } = request.params
+    return handleToolCall(client, name, args ?? {})
+  },
+)
+
+// -- Resources ---------------------------------------------------------------
+
+server.setRequestHandler(
+  ListResourcesRequestSchema,
+  async () => ({
+    resources: staticResources.map((r) => ({
+      uri: r.uri,
+      name: r.name,
+      description: r.description,
+      mimeType: r.mimeType,
+    })),
+  }),
+)
+
+server.setRequestHandler(
+  ListResourceTemplatesRequestSchema,
+  async () => ({
+    resourceTemplates: resourceTemplates.map((t) => ({
+      uriTemplate: t.uriTemplate,
+      name: t.name,
+      description: t.description,
+      mimeType: t.mimeType,
+    })),
+  }),
+)
+
+server.setRequestHandler(
+  ReadResourceRequestSchema,
+  async (request) => {
+    const uri = request.params.uri
+
+    // Check static resources first
+    for (const resource of staticResources) {
+      if (uri === resource.uri) {
+        const text = await resource.handler(client, {})
+        return {
+          contents: [
+            {
+              uri: resource.uri,
+              mimeType: resource.mimeType,
+              text,
+            },
+          ],
+        }
+      }
+    }
+
+    // Check resource templates
+    for (const template of resourceTemplates) {
+      const params = matchUriTemplate(
+        template.uriTemplate,
+        uri,
+      )
+      if (params) {
+        const text = await template.handler(client, params)
+        return {
+          contents: [
+            {
+              uri,
+              mimeType: template.mimeType,
+              text,
+            },
+          ],
+        }
+      }
+    }
+
+    throw new Error(`Resource not found: ${uri}`)
+  },
+)
+
+// -- Prompts -----------------------------------------------------------------
+
+server.setRequestHandler(
+  ListPromptsRequestSchema,
+  async () => ({
+    prompts: prompts.map((p) => ({
+      name: p.name,
+      description: p.description,
+      arguments: p.arguments,
+    })),
+  }),
+)
+
+server.setRequestHandler(
+  GetPromptRequestSchema,
+  async (request) => {
+    const { name, arguments: args } = request.params
+    const prompt = prompts.find((p) => p.name === name)
+    if (!prompt) {
+      throw new Error(`Prompt not found: ${name}`)
+    }
+    const stringArgs: Record<string, string> = {}
+    if (args) {
+      for (const [key, value] of Object.entries(args)) {
+        if (value !== undefined) {
+          stringArgs[key] = String(value)
+        }
+      }
+    }
+    return { messages: prompt.handler(stringArgs) }
+  },
+)
+
+// -- URI template matching helper --------------------------------------------
+
+/**
+ * Matches a URI against a simple URI template with {param} placeholders.
+ * Returns extracted params or null if no match.
+ */
+function matchUriTemplate(
+  template: string,
+  uri: string,
+): Record<string, string> | null {
+  const paramNames: string[] = []
+  const regexStr = template.replace(
+    /\{([^}]+)\}/g,
+    (_match, paramName: string) => {
+      paramNames.push(paramName)
+      return "([^/]+)"
+    },
+  )
+  const match = new RegExp(`^${regexStr}$`).exec(uri)
+  if (!match) return null
+  const params: Record<string, string> = {}
+  paramNames.forEach((name, i) => {
+    params[name] = match[i + 1]
+  })
+  return params
+}
+
+// -- Start server ------------------------------------------------------------
+
+async function main(): Promise<void> {
+  const transport = new StdioServerTransport()
+  await server.connect(transport)
+  console.error("OneSchema MCP server running on stdio")
+}
+
+main().catch((err) => {
+  console.error("Fatal error:", err)
+  process.exit(1)
+})

--- a/packages/mcp-server/src/node-types.ts
+++ b/packages/mcp-server/src/node-types.ts
@@ -1,0 +1,257 @@
+/**
+ * Static reference data for all flowgraph node types.
+ *
+ * This is exposed as an MCP resource so AI assistants know the vocabulary
+ * for constructing valid flowgraph DAGs.
+ */
+
+export interface NodeTypeInfo {
+  type: string
+  label: string
+  description: string
+  is_default: boolean
+  singleton: boolean
+  requires_pipeline: boolean
+  input_type: string | null
+  runner_keys: string[]
+}
+
+export const NODE_TYPES: NodeTypeInfo[] = [
+  // Default nodes
+  {
+    type: "source",
+    label: "Source files",
+    description:
+      "Entry point for the workflow. Uploaded files arrive at this node.",
+    is_default: true,
+    singleton: true,
+    requires_pipeline: false,
+    input_type: null,
+    runner_keys: [],
+  },
+  {
+    type: "import",
+    label: "Import files",
+    description:
+      "Terminal node that finalizes the import. Maps templates to processed data.",
+    is_default: true,
+    singleton: true,
+    requires_pipeline: false,
+    input_type: "lists",
+    runner_keys: ["template_mapping"],
+  },
+  {
+    type: "help-text",
+    label: "Help text",
+    description:
+      "Default informational node. Does not process data.",
+    is_default: true,
+    singleton: true,
+    requires_pipeline: false,
+    input_type: null,
+    runner_keys: [],
+  },
+  {
+    type: "post-import-file-action",
+    label: "Post import file action",
+    description:
+      "Runs a workflow code action after import completes. References a workflow_code_action_key.",
+    is_default: false,
+    singleton: true,
+    requires_pipeline: false,
+    input_type: "lists",
+    runner_keys: ["workflow_code_action_key"],
+  },
+  // List-processing nodes
+  {
+    type: "single-list",
+    label: "Sheet transforms",
+    description:
+      "Applies column mapping, validation, and transforms to a single sheet. Requires a pipeline with a template_key.",
+    is_default: false,
+    singleton: false,
+    requires_pipeline: true,
+    input_type: "lists",
+    runner_keys: ["template_key"],
+  },
+  {
+    type: "split-list",
+    label: "Split sheet by row count",
+    description:
+      "Splits a sheet into multiple sheets with a maximum number of rows each.",
+    is_default: false,
+    singleton: false,
+    requires_pipeline: false,
+    input_type: "lists",
+    runner_keys: ["max_rows_per_file"],
+  },
+  {
+    type: "merge-rows",
+    label: "Combine sheets by row",
+    description:
+      "Combines multiple sheets into a single sheet by appending rows.",
+    is_default: false,
+    singleton: false,
+    requires_pipeline: false,
+    input_type: "lists",
+    runner_keys: ["output_file_name"],
+  },
+  {
+    type: "join-lists",
+    label: "Join sheets by column",
+    description:
+      "Joins two sheets by matching column values (like a SQL JOIN).",
+    is_default: false,
+    singleton: false,
+    requires_pipeline: false,
+    input_type: "lists",
+    runner_keys: [
+      "left_key_column",
+      "right_key_column",
+      "right_list_prefix",
+      "output_file_name",
+    ],
+  },
+  {
+    type: "ai-classify-values",
+    label: "Categorize data",
+    description:
+      "Uses AI to classify/categorize values in a column based on training data.",
+    is_default: false,
+    singleton: false,
+    requires_pipeline: false,
+    input_type: "lists",
+    runner_keys: [
+      "input_column_name",
+      "output_column_name",
+      "training_input_column_name",
+      "training_output_column_name",
+      "enums_column_name",
+    ],
+  },
+  // File-processing nodes
+  {
+    type: "excel-extract",
+    label: "Extract Excel worksheets",
+    description:
+      "Splits an Excel file into individual sheet CSVs. Can target specific sheets or all sheets.",
+    is_default: false,
+    singleton: false,
+    requires_pipeline: false,
+    input_type: "files",
+    runner_keys: ["sheet_names", "all_sheets"],
+  },
+  {
+    type: "pdf-extract",
+    label: "Extract PDF data",
+    description:
+      "Extracts structured data from PDF files using an AI provider (OpenAI or Gemini).",
+    is_default: false,
+    singleton: false,
+    requires_pipeline: false,
+    input_type: "files",
+    runner_keys: [
+      "provider_type",
+      "output_replica_count",
+      "consistency_threshold",
+      "user_prompt",
+      "column_definitions",
+    ],
+  },
+  {
+    type: "pdf-split",
+    label: "Split PDF by page",
+    description: "Splits a multi-page PDF into individual page PDFs.",
+    is_default: false,
+    singleton: false,
+    requires_pipeline: false,
+    input_type: "files",
+    runner_keys: [],
+  },
+  {
+    type: "unzip-extract",
+    label: "Unzip file",
+    description: "Extracts files from a ZIP archive.",
+    is_default: false,
+    singleton: false,
+    requires_pipeline: false,
+    input_type: "files",
+    runner_keys: [],
+  },
+  {
+    type: "fixed-width-parse",
+    label: "Convert fixed-width file",
+    description:
+      "Parses a fixed-width text file into columnar data.",
+    is_default: false,
+    singleton: false,
+    requires_pipeline: false,
+    input_type: "files",
+    runner_keys: [],
+  },
+  {
+    type: "decrypt-file",
+    label: "Decrypt file",
+    description: "Decrypts an encrypted file.",
+    is_default: false,
+    singleton: false,
+    requires_pipeline: false,
+    input_type: "files",
+    runner_keys: [],
+  },
+  {
+    type: "convert-to-pdf",
+    label: "Convert to PDF",
+    description: "Converts a file to PDF format.",
+    is_default: false,
+    singleton: false,
+    requires_pipeline: false,
+    input_type: "files",
+    runner_keys: [],
+  },
+  // Any-processing nodes
+  {
+    type: "custom-file-action",
+    label: "Custom file transform",
+    description:
+      "Runs custom JavaScript code to transform files. Config includes a 'code' field.",
+    is_default: false,
+    singleton: false,
+    requires_pipeline: false,
+    input_type: "any",
+    runner_keys: ["code"],
+  },
+  {
+    type: "csv-agent",
+    label: "CSV transforms with AI",
+    description:
+      "Uses an AI agent to transform CSV data. Config includes 'code' and 'template_key'.",
+    is_default: false,
+    singleton: false,
+    requires_pipeline: false,
+    input_type: "any",
+    runner_keys: ["code", "template_key"],
+  },
+  {
+    type: "file-agent",
+    label: "File transforms agent",
+    description:
+      "Uses an AI agent to transform files. Config includes a 'code' field.",
+    is_default: false,
+    singleton: false,
+    requires_pipeline: false,
+    input_type: "any",
+    runner_keys: ["code"],
+  },
+  {
+    type: "call-workflow",
+    label: "Call Multi FileFeed",
+    description:
+      "Calls another workflow as a sub-workflow. Config references a workflow_name.",
+    is_default: false,
+    singleton: false,
+    requires_pipeline: false,
+    input_type: "any",
+    runner_keys: ["workflow_name"],
+  },
+]

--- a/packages/mcp-server/src/prompts.ts
+++ b/packages/mcp-server/src/prompts.ts
@@ -1,0 +1,106 @@
+/**
+ * MCP prompt definitions for common OneSchema workflow tasks.
+ */
+
+import { NODE_TYPES } from "./node-types.js"
+
+export interface PromptDefinition {
+  name: string
+  description: string
+  arguments: {
+    name: string
+    description: string
+    required: boolean
+  }[]
+  handler: (args: Record<string, string>) => {
+    role: "user"
+    content: { type: "text"; text: string }
+  }[]
+}
+
+export const prompts: PromptDefinition[] = [
+  // -- create_simple_workflow ------------------------------------------------
+  {
+    name: "create_simple_workflow",
+    description:
+      "Guide for creating a basic Multi FileFeed with a source -> sheet transforms -> import pipeline. Returns a prompt that helps you construct the right tool calls.",
+    arguments: [
+      {
+        name: "workflow_name",
+        description: "The name for the new workflow",
+        required: true,
+      },
+      {
+        name: "template_key",
+        description:
+          "The template key to use for the sheet transforms step",
+        required: true,
+      },
+    ],
+    handler: (args) => {
+      const workflowName = args.workflow_name ?? "My Workflow"
+      const templateKey = args.template_key ?? "my_template"
+      return [
+        {
+          role: "user" as const,
+          content: {
+            type: "text" as const,
+            text: `Create a Multi FileFeed named "${workflowName}" with the following structure:
+
+1. A **source** node where files are uploaded
+2. A **single-list** (sheet transforms) node that processes data using the template "${templateKey}"
+3. An **import** node that finalizes the processed data
+
+This is the most common workflow pattern. You can use the \`create_simple_workflow\` tool with:
+- name: "${workflowName}"
+- template_key: "${templateKey}"
+
+Or for more control, use \`create_workflow_from_flowgraph\` with a full flowgraph payload. Remember to include the three default nodes (source, import, help-text) in any flowgraph.`,
+          },
+        },
+      ]
+    },
+  },
+
+  // -- describe_workflow -----------------------------------------------------
+  {
+    name: "describe_workflow",
+    description:
+      "Export a workflow's flowgraph and describe its structure in plain English. Helps understand what an existing workflow does before modifying or duplicating it.",
+    arguments: [
+      {
+        name: "workflow_id",
+        description: "The Multi FileFeed ID to describe",
+        required: true,
+      },
+    ],
+    handler: (args) => {
+      const workflowId = args.workflow_id ?? "1"
+
+      const nodeTypeSummary = NODE_TYPES.map(
+        (n) => `- **${n.type}**: ${n.description}`,
+      ).join("\n")
+
+      return [
+        {
+          role: "user" as const,
+          content: {
+            type: "text" as const,
+            text: `Please describe the structure of workflow ${workflowId}. Follow these steps:
+
+1. Use \`export_flowgraph\` with workflow_id: ${workflowId} to get the flowgraph JSON
+2. Analyze the nodes and edges to understand the data flow
+3. Describe the workflow in plain English, explaining:
+   - What files it expects as input
+   - What processing steps are applied (and in what order)
+   - What templates are used for validation/mapping
+   - What the final output looks like
+
+Here are the available node types for reference:
+${nodeTypeSummary}`,
+          },
+        },
+      ]
+    },
+  },
+]

--- a/packages/mcp-server/src/resources.ts
+++ b/packages/mcp-server/src/resources.ts
@@ -1,0 +1,85 @@
+/**
+ * MCP resource definitions for OneSchema data.
+ *
+ * Resources are read-only data endpoints that AI assistants can browse.
+ */
+
+import type { OneSchemaClient } from "./api-client.js"
+import { NODE_TYPES } from "./node-types.js"
+
+export interface ResourceDefinition {
+  uri: string
+  name: string
+  description: string
+  mimeType: string
+  handler: (
+    client: OneSchemaClient,
+    params: Record<string, string>,
+  ) => Promise<string>
+}
+
+export interface ResourceTemplateDefinition {
+  uriTemplate: string
+  name: string
+  description: string
+  mimeType: string
+  handler: (
+    client: OneSchemaClient,
+    params: Record<string, string>,
+  ) => Promise<string>
+}
+
+// -- Static resources --------------------------------------------------------
+
+export const staticResources: ResourceDefinition[] = [
+  {
+    uri: "oneschema://node-types",
+    name: "Flowgraph Node Types Reference",
+    description:
+      "Complete reference of all available flowgraph node types, including descriptions, input types, and configuration keys. Use this to understand what nodes you can include when building a flowgraph.",
+    mimeType: "application/json",
+    handler: async () => {
+      return JSON.stringify(NODE_TYPES, null, 2)
+    },
+  },
+  {
+    uri: "oneschema://workflows",
+    name: "All Workflows",
+    description:
+      "List of all Multi FileFeeds (workflows) in the organization.",
+    mimeType: "application/json",
+    handler: async (client) => {
+      const workflows = await client.listWorkflows()
+      return JSON.stringify(workflows, null, 2)
+    },
+  },
+]
+
+// -- Dynamic resource templates ----------------------------------------------
+
+export const resourceTemplates: ResourceTemplateDefinition[] = [
+  {
+    uriTemplate: "oneschema://workflows/{workflow_id}",
+    name: "Workflow Details",
+    description:
+      "Full details of a specific Multi FileFeed including templates, source, destination, and event webhooks.",
+    mimeType: "application/json",
+    handler: async (client, params) => {
+      const workflowId = parseInt(params.workflow_id, 10)
+      const workflow = await client.getWorkflow(workflowId)
+      return JSON.stringify(workflow, null, 2)
+    },
+  },
+  {
+    uriTemplate: "oneschema://workflows/{workflow_id}/flowgraph",
+    name: "Workflow Flowgraph",
+    description:
+      "The portable flowgraph JSON for a specific workflow, showing all nodes and edges in the processing DAG.",
+    mimeType: "application/json",
+    handler: async (client, params) => {
+      const workflowId = parseInt(params.workflow_id, 10)
+      const flowgraph = await client.exportFlowgraph(workflowId)
+      return JSON.stringify(flowgraph, null, 2)
+    },
+  },
+]

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -1,0 +1,558 @@
+/**
+ * MCP tool definitions for OneSchema workflow and flowgraph operations.
+ *
+ * Uses plain JSON Schema tool descriptors and a dispatch function to avoid
+ * TypeScript deep type instantiation issues with McpServer's generic
+ * Zod-based tool() method.
+ */
+
+import type { OneSchemaClient } from "./api-client.js"
+import type {
+  CallToolResult,
+  Tool,
+} from "@modelcontextprotocol/sdk/types.js"
+import type { FlowgraphExport, OneSchemaApiError } from "./types.js"
+
+// -- Helpers ----------------------------------------------------------------
+
+function ok(result: unknown): CallToolResult {
+  return {
+    content: [
+      { type: "text", text: JSON.stringify(result, null, 2) },
+    ],
+  }
+}
+
+function apiError(err: unknown): CallToolResult {
+  const apiErr = err as OneSchemaApiError
+  if (apiErr.status) {
+    return {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify(
+            {
+              error: apiErr.message,
+              status: apiErr.status,
+              details: apiErr.details,
+            },
+            null,
+            2,
+          ),
+        },
+      ],
+      isError: true,
+    }
+  }
+  throw err
+}
+
+// -- Tool descriptors (JSON Schema, no Zod) ---------------------------------
+
+const FLOWGRAPH_NODE_TYPES = [
+  "source",
+  "import",
+  "help-text",
+  "post-import-file-action",
+  "single-list",
+  "split-list",
+  "merge-rows",
+  "join-lists",
+  "ai-classify-values",
+  "excel-extract",
+  "pdf-extract",
+  "pdf-split",
+  "unzip-extract",
+  "fixed-width-parse",
+  "decrypt-file",
+  "custom-file-action",
+  "csv-agent",
+  "file-agent",
+  "convert-to-pdf",
+  "call-workflow",
+]
+
+export const toolDefinitions: Tool[] = [
+  {
+    name: "list_workflows",
+    description:
+      "List all Multi FileFeeds (workflows) in the organization. Optionally filter by folder.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        folder_id: {
+          type: "number",
+          description: "Filter workflows by folder ID",
+        },
+      },
+    },
+  },
+  {
+    name: "get_workflow",
+    description:
+      "Get full details of a Multi FileFeed (workflow) by its ID, including templates, source, destination, and event webhooks.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        workflow_id: {
+          type: "number",
+          description: "The Multi FileFeed ID",
+        },
+      },
+      required: ["workflow_id"],
+    },
+  },
+  {
+    name: "export_flowgraph",
+    description:
+      "Export the flowgraph (DAG of processing nodes and edges) for a Multi FileFeed as portable JSON. Use this to understand an existing workflow's structure before creating or modifying one.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        workflow_id: {
+          type: "number",
+          description: "The Multi FileFeed ID to export",
+        },
+      },
+      required: ["workflow_id"],
+    },
+  },
+  {
+    name: "create_workflow_from_flowgraph",
+    description:
+      "Create a new Multi FileFeed by importing a portable flowgraph JSON definition. The payload format matches the output of export_flowgraph. Every flowgraph must include the three default nodes (source, import, help-text) plus any custom processing nodes connected by edges.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        name: {
+          type: "string",
+          description: "Name for the new workflow",
+        },
+        folder_id: {
+          type: "number",
+          description: "Folder ID to place the workflow in",
+        },
+        flowgraph: {
+          type: "object",
+          description: "The portable flowgraph JSON payload",
+          properties: {
+            version: {
+              type: "number",
+              description: "Schema version (must be 0)",
+            },
+            source_workflow_name: {
+              type: "string",
+              description:
+                "Name of the source workflow this was derived from",
+            },
+            templates: {
+              type: "array",
+              description: "Top-level template declarations",
+              items: {
+                type: "object",
+                properties: {
+                  template_key: { type: "string" },
+                  is_required: { type: "boolean" },
+                },
+                required: ["template_key", "is_required"],
+              },
+            },
+            flowgraph: {
+              type: "object",
+              properties: {
+                nodes: {
+                  type: "array",
+                  items: {
+                    type: "object",
+                    properties: {
+                      node_key: { type: "string" },
+                      type: {
+                        type: "string",
+                        enum: FLOWGRAPH_NODE_TYPES,
+                      },
+                      config: { type: "object" },
+                      position_x: { type: "number" },
+                      position_y: { type: "number" },
+                      pipeline: { type: "object" },
+                    },
+                    required: ["node_key", "type", "config"],
+                  },
+                },
+                edges: {
+                  type: "array",
+                  items: {
+                    type: "object",
+                    properties: {
+                      from_node_key: { type: "string" },
+                      to_node_key: { type: "string" },
+                    },
+                    required: ["from_node_key", "to_node_key"],
+                  },
+                },
+              },
+              required: ["nodes", "edges"],
+            },
+          },
+          required: [
+            "version",
+            "source_workflow_name",
+            "flowgraph",
+          ],
+        },
+      },
+      required: ["name", "flowgraph"],
+    },
+  },
+  {
+    name: "create_simple_workflow",
+    description:
+      "Create a simple Multi FileFeed with a basic source -> single-list (sheet transforms) -> import pipeline. This is a convenience tool that generates the flowgraph JSON automatically from a template key.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        name: {
+          type: "string",
+          description: "Name for the new workflow",
+        },
+        template_key: {
+          type: "string",
+          description:
+            "Template key for the sheet transforms step",
+        },
+        is_template_required: {
+          type: "boolean",
+          description:
+            "Whether the template is required (default: true)",
+        },
+        folder_id: {
+          type: "number",
+          description: "Folder ID to place the workflow in",
+        },
+      },
+      required: ["name", "template_key"],
+    },
+  },
+  {
+    name: "duplicate_workflow",
+    description:
+      "Duplicate an existing Multi FileFeed with a new name. The new workflow is a full copy including its flowgraph and pipeline configuration.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        workflow_id: {
+          type: "number",
+          description: "The Multi FileFeed ID to duplicate",
+        },
+        name: {
+          type: "string",
+          description: "Name for the duplicated workflow",
+        },
+      },
+      required: ["workflow_id", "name"],
+    },
+  },
+  {
+    name: "update_workflow",
+    description:
+      "Update a Multi FileFeed's metadata: name, folder, source (SFTP), or destination (SFTP).",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        workflow_id: {
+          type: "number",
+          description: "The Multi FileFeed ID to update",
+        },
+        name: { type: "string", description: "New name" },
+        folder_id: {
+          type: "number",
+          description: "Move to this folder ID",
+        },
+        source: {
+          type: "object",
+          description: "SFTP source config, or null to remove",
+        },
+        destination: {
+          type: "object",
+          description:
+            "SFTP destination config, or null to remove",
+        },
+      },
+      required: ["workflow_id"],
+    },
+  },
+  {
+    name: "delete_workflow",
+    description:
+      "Permanently delete a Multi FileFeed and all its associated data.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        workflow_id: {
+          type: "number",
+          description: "The Multi FileFeed ID to delete",
+        },
+      },
+      required: ["workflow_id"],
+    },
+  },
+  {
+    name: "get_template",
+    description:
+      "Export a template by its key. Returns the full template definition including columns, validation rules, and hooks.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        template_key: {
+          type: "string",
+          description: "The template key to export",
+        },
+      },
+      required: ["template_key"],
+    },
+  },
+  {
+    name: "create_template",
+    description:
+      "Create a new template. Templates define the expected schema (columns, data types, validation) for data imported through a workflow.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        name: {
+          type: "string",
+          description: "Display name for the template",
+        },
+        template_key: {
+          type: "string",
+          description:
+            "Unique key identifier (e.g. 'invoices', 'customer_orders')",
+        },
+        columns: {
+          type: "array",
+          description: "Column definitions for the template",
+          items: {
+            type: "object",
+            properties: {
+              label: {
+                type: "string",
+                description: "Column display label",
+              },
+              key: {
+                type: "string",
+                description: "Column key identifier",
+              },
+              data_type: {
+                type: "string",
+                description:
+                  "Validation data type (e.g. EMAIL, NUMBER, DATE)",
+              },
+              is_required: {
+                type: "boolean",
+                description: "Whether this column is required",
+              },
+              is_unique: {
+                type: "boolean",
+                description: "Whether values must be unique",
+              },
+              description: {
+                type: "string",
+                description: "Column description",
+              },
+            },
+            required: ["label", "key"],
+          },
+        },
+      },
+      required: ["name", "template_key", "columns"],
+    },
+  },
+]
+
+// -- Tool handler dispatch --------------------------------------------------
+
+type ToolArgs = Record<string, unknown>
+
+export async function handleToolCall(
+  client: OneSchemaClient,
+  name: string,
+  args: ToolArgs,
+): Promise<CallToolResult> {
+  try {
+    switch (name) {
+      case "list_workflows":
+        return ok(
+          await client.listWorkflows(
+            args.folder_id as number | undefined,
+          ),
+        )
+
+      case "get_workflow":
+        return ok(
+          await client.getWorkflow(args.workflow_id as number),
+        )
+
+      case "export_flowgraph":
+        return ok(
+          await client.exportFlowgraph(
+            args.workflow_id as number,
+          ),
+        )
+
+      case "create_workflow_from_flowgraph":
+        return ok(
+          await client.createWorkflowFromFlowgraph({
+            name: args.name as string,
+            folder_id: args.folder_id as number | undefined,
+            flowgraph:
+              args.flowgraph as unknown as FlowgraphExport,
+          }),
+        )
+
+      case "create_simple_workflow": {
+        const templateKey = args.template_key as string
+        const isRequired =
+          (args.is_template_required as boolean | undefined) ??
+          true
+        const workflowName = args.name as string
+
+        const flowgraph: FlowgraphExport = {
+          version: 0,
+          exported_at: new Date().toISOString(),
+          source_workflow_name: workflowName,
+          templates: [
+            {
+              template_key: templateKey,
+              is_required: isRequired,
+            },
+          ],
+          flowgraph: {
+            nodes: [
+              {
+                node_key: "source-node",
+                type: "source",
+                config: {},
+                position_x: 0,
+                position_y: 100,
+              },
+              {
+                node_key: "transform-node",
+                type: "single-list",
+                config: {
+                  runner: { template_key: templateKey },
+                },
+                position_x: 250,
+                position_y: 100,
+                pipeline: {
+                  template_key: templateKey,
+                  config: {},
+                  prompt_generated_code_actions: [],
+                },
+              },
+              {
+                node_key: "import-node",
+                type: "import",
+                config: {},
+                position_x: 500,
+                position_y: 100,
+              },
+              {
+                node_key: "help-text-node",
+                type: "help-text",
+                config: {},
+                position_x: 0,
+                position_y: 0,
+              },
+            ],
+            edges: [
+              {
+                from_node_key: "source-node",
+                to_node_key: "transform-node",
+              },
+              {
+                from_node_key: "transform-node",
+                to_node_key: "import-node",
+              },
+            ],
+          },
+        }
+
+        return ok(
+          await client.createWorkflowFromFlowgraph({
+            name: workflowName,
+            folder_id: args.folder_id as number | undefined,
+            flowgraph,
+          }),
+        )
+      }
+
+      case "duplicate_workflow":
+        return ok(
+          await client.duplicateWorkflow(
+            args.workflow_id as number,
+            args.name as string,
+          ),
+        )
+
+      case "update_workflow": {
+        const updates: Record<string, unknown> = {}
+        if (args.name !== undefined) updates.name = args.name
+        if (args.folder_id !== undefined)
+          updates.folder_id = args.folder_id
+        if (args.source !== undefined)
+          updates.source = args.source
+        if (args.destination !== undefined)
+          updates.destination = args.destination
+        return ok(
+          await client.updateWorkflow(
+            args.workflow_id as number,
+            updates as Parameters<
+              typeof client.updateWorkflow
+            >[1],
+          ),
+        )
+      }
+
+      case "delete_workflow":
+        return ok(
+          await client.deleteWorkflow(
+            args.workflow_id as number,
+          ),
+        )
+
+      case "get_template":
+        return ok(
+          await client.getTemplate(
+            args.template_key as string,
+          ),
+        )
+
+      case "create_template":
+        return ok(
+          await client.createTemplate({
+            name: args.name as string,
+            template_key: args.template_key as string,
+            columns: args.columns as {
+              label: string
+              key: string
+              data_type?: string
+              is_required?: boolean
+              is_unique?: boolean
+              description?: string
+            }[],
+          }),
+        )
+
+      default:
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Unknown tool: ${name}`,
+            },
+          ],
+          isError: true,
+        }
+    }
+  } catch (err) {
+    return apiError(err)
+  }
+}

--- a/packages/mcp-server/src/types.ts
+++ b/packages/mcp-server/src/types.ts
@@ -1,0 +1,120 @@
+/**
+ * Type definitions for OneSchema API responses and flowgraph structures.
+ */
+
+// -- Workflow types ----------------------------------------------------------
+
+export interface WorkflowSummary {
+  id: number
+  name: string
+  workspace_id: number | null
+}
+
+export interface WorkflowTemplate {
+  name: string
+  description: string | null
+  key: string
+}
+
+export interface WorkflowSftpTarget {
+  type: string
+  data: Record<string, unknown>
+}
+
+export interface WorkflowEventWebhook {
+  url: string
+  secret_key: string | null
+}
+
+export interface Workflow {
+  id: number
+  workspace_id: number | null
+  name: string
+  custom_metadata: Record<string, unknown>
+  templates: WorkflowTemplate[]
+  source: WorkflowSftpTarget[]
+  destination: WorkflowSftpTarget[]
+  event_webhooks: WorkflowEventWebhook[]
+  post_validation_transform_key: string | null
+}
+
+// -- Flowgraph portable JSON types -------------------------------------------
+
+export interface FlowgraphPromptGeneratedCodeAction {
+  key: string
+  label: string
+  user_prompt: string
+  code: string
+}
+
+export interface FlowgraphPipeline {
+  template_key: string | null
+  config: Record<string, unknown>
+  prompt_generated_code_actions: FlowgraphPromptGeneratedCodeAction[]
+}
+
+export interface FlowgraphNode {
+  node_key: string
+  type: string
+  config: Record<string, unknown>
+  position_x?: number | null
+  position_y?: number | null
+  pipeline?: FlowgraphPipeline
+}
+
+export interface FlowgraphEdge {
+  from_node_key: string
+  to_node_key: string
+}
+
+export interface FlowgraphTemplateEntry {
+  template_key: string
+  is_required: boolean
+}
+
+export interface FlowgraphExport {
+  version: number
+  exported_at: string
+  source_workflow_name: string
+  templates?: FlowgraphTemplateEntry[]
+  flowgraph: {
+    nodes: FlowgraphNode[]
+    edges: FlowgraphEdge[]
+  }
+}
+
+// -- Template types ----------------------------------------------------------
+
+export interface TemplateColumn {
+  label: string
+  key: string
+  data_type?: string | null
+  validation_options?: Record<string, unknown>
+  is_required?: boolean
+  is_unique?: boolean
+  letter_case?: string
+  min_char_limit?: number
+  max_char_limit?: number
+  delimiter?: string
+  must_exist?: boolean
+  is_custom?: boolean
+  description?: string
+  default_value?: string
+  mapping_hints?: string[]
+}
+
+export interface TemplateExport {
+  name: string
+  template_key: string
+  columns: TemplateColumn[]
+  row_constraints?: Record<string, unknown>[]
+  validation_hooks?: Record<string, unknown>[]
+}
+
+// -- API error ---------------------------------------------------------------
+
+export interface OneSchemaApiError {
+  status: number
+  message: string
+  details?: unknown
+}

--- a/packages/mcp-server/tsconfig.json
+++ b/packages/mcp-server/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1659,6 +1659,11 @@
   resolved "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz"
   integrity sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==
 
+"@hono/node-server@^1.19.9":
+  version "1.19.12"
+  resolved "https://registry.yarnpkg.com/@hono/node-server/-/node-server-1.19.12.tgz#dae075247959b6d7d2dba4c8bdc8c452ca0c7b40"
+  integrity sha512-txsUW4SQ1iilgE0l9/e9VQWmELXifEFvmdA1j6WFh/aFPj99hIntrSsq/if0UWyGVkmrRPKA1wCeP+UCr1B9Uw==
+
 "@humanwhocodes/config-array@^0.11.8":
   version "0.11.8"
   resolved "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.8.tgz"
@@ -1814,6 +1819,29 @@
     "@lezer/common" "^0.15.7"
     "@lezer/lr" "^0.15.4"
     json5 "^2.2.1"
+
+"@modelcontextprotocol/sdk@^1.12.1":
+  version "1.29.0"
+  resolved "https://registry.yarnpkg.com/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz#79786d8b525e269de850ac82b1f1f757f3915f44"
+  integrity sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==
+  dependencies:
+    "@hono/node-server" "^1.19.9"
+    ajv "^8.17.1"
+    ajv-formats "^3.0.1"
+    content-type "^1.0.5"
+    cors "^2.8.5"
+    cross-spawn "^7.0.5"
+    eventsource "^3.0.2"
+    eventsource-parser "^3.0.0"
+    express "^5.2.1"
+    express-rate-limit "^8.2.1"
+    hono "^4.11.4"
+    jose "^6.1.3"
+    json-schema-typed "^8.0.2"
+    pkce-challenge "^5.0.0"
+    raw-body "^3.0.0"
+    zod "^3.25 || ^4.0"
+    zod-to-json-schema "^3.25.1"
 
 "@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.2":
   version "3.0.2"
@@ -2814,6 +2842,13 @@
   resolved "https://registry.npmjs.org/@types/node/-/node-18.15.10.tgz"
   integrity sha512-9avDaQJczATcXgfmMAW3MIWArOO7A+m90vuCFLr8AotWf8igO/mRoYukrk2cqZVtv38tHs33retzHEilM7FpeQ==
 
+"@types/node@^22.15.2":
+  version "22.19.17"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.19.17.tgz#09c71fb34ba2510f8ac865361b1fcb9552b8a581"
+  integrity sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==
+  dependencies:
+    undici-types "~6.21.0"
+
 "@types/parse-json@^4.0.0":
   version "4.0.0"
   resolved "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz"
@@ -3246,6 +3281,14 @@ abortcontroller-polyfill@^1.1.9:
   resolved "https://registry.npmjs.org/abortcontroller-polyfill/-/abortcontroller-polyfill-1.7.5.tgz"
   integrity sha512-JMJ5soJWP18htbbxJjG7bG6yuI6pRhgJ0scHHTfkUjf6wjP912xZWvM+A4sJK3gqd9E8fcPbDnOefbA9Th/FIQ==
 
+accepts@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/accepts/-/accepts-2.0.0.tgz#bbcf4ba5075467f3f2131eab3cffc73c2f5d7895"
+  integrity sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==
+  dependencies:
+    mime-types "^3.0.0"
+    negotiator "^1.0.0"
+
 accepts@~1.3.4, accepts@~1.3.5, accepts@~1.3.8:
   version "1.3.8"
   resolved "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz"
@@ -3324,6 +3367,13 @@ ajv-formats@2.1.1, ajv-formats@^2.1.1:
   dependencies:
     ajv "^8.0.0"
 
+ajv-formats@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/ajv-formats/-/ajv-formats-3.0.1.tgz#3d5dc762bca17679c3c2ea7e90ad6b7532309578"
+  integrity sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==
+  dependencies:
+    ajv "^8.0.0"
+
 ajv-keywords@^3.5.2:
   version "3.5.2"
   resolved "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz"
@@ -3355,6 +3405,16 @@ ajv@^6.10.0, ajv@^6.12.4, ajv@^6.12.5:
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
+
+ajv@^8.17.1:
+  version "8.18.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.18.0.tgz#8864186b6738d003eb3a933172bb3833e10cefbc"
+  integrity sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==
+  dependencies:
+    fast-deep-equal "^3.1.3"
+    fast-uri "^3.0.1"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
 
 ansi-colors@4.1.3, ansi-colors@^4.1.3:
   version "4.1.3"
@@ -3652,6 +3712,21 @@ body-parser@^1.19.0:
     type-is "~1.6.18"
     unpipe "1.0.0"
 
+body-parser@^2.2.1:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-2.2.2.tgz#1a32cdb966beaf68de50a9dfbe5b58f83cb8890c"
+  integrity sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==
+  dependencies:
+    bytes "^3.1.2"
+    content-type "^1.0.5"
+    debug "^4.4.3"
+    http-errors "^2.0.0"
+    iconv-lite "^0.7.0"
+    on-finished "^2.4.1"
+    qs "^6.14.1"
+    raw-body "^3.0.1"
+    type-is "^2.0.1"
+
 bonjour-service@^1.0.11:
   version "1.1.1"
   resolved "https://registry.npmjs.org/bonjour-service/-/bonjour-service-1.1.1.tgz"
@@ -3744,7 +3819,7 @@ bytes@3.0.0:
   resolved "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz"
   integrity sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw==
 
-bytes@3.1.2:
+bytes@3.1.2, bytes@^3.1.2, bytes@~3.1.2:
   version "3.1.2"
   resolved "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz"
   integrity sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==
@@ -3825,6 +3900,14 @@ call-bind@^1.0.0, call-bind@^1.0.2:
   dependencies:
     function-bind "^1.1.1"
     get-intrinsic "^1.0.2"
+
+call-bound@^1.0.2:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/call-bound/-/call-bound-1.0.4.tgz#238de935d2a2a692928c538c7ccfa91067fd062a"
+  integrity sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==
+  dependencies:
+    call-bind-apply-helpers "^1.0.2"
+    get-intrinsic "^1.3.0"
 
 callsites@^3.0.0:
   version "3.1.0"
@@ -4072,7 +4155,12 @@ content-disposition@0.5.4:
   dependencies:
     safe-buffer "5.2.1"
 
-content-type@~1.0.4, content-type@~1.0.5:
+content-disposition@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/content-disposition/-/content-disposition-1.0.1.tgz#a8b7bbeb2904befdfb6787e5c0c086959f605f9b"
+  integrity sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==
+
+content-type@^1.0.5, content-type@~1.0.4, content-type@~1.0.5:
   version "1.0.5"
   resolved "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz"
   integrity sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==
@@ -4092,10 +4180,20 @@ cookie-signature@1.0.6:
   resolved "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz"
   integrity sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==
 
+cookie-signature@^1.2.1:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/cookie-signature/-/cookie-signature-1.2.2.tgz#57c7fc3cc293acab9fec54d73e15690ebe4a1793"
+  integrity sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==
+
 cookie@0.5.0:
   version "0.5.0"
   resolved "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz"
   integrity sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==
+
+cookie@^0.7.1:
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.7.2.tgz#556369c472a2ba910f2979891b526b3436237ed7"
+  integrity sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==
 
 cookie@~0.4.1:
   version "0.4.2"
@@ -4132,6 +4230,14 @@ core-util-is@~1.0.0:
   version "1.0.3"
   resolved "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz"
   integrity sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==
+
+cors@^2.8.5:
+  version "2.8.6"
+  resolved "https://registry.yarnpkg.com/cors/-/cors-2.8.6.tgz#ff5dd69bd95e547503820d29aba4f8faf8dfec96"
+  integrity sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==
+  dependencies:
+    object-assign "^4"
+    vary "^1"
 
 cors@~2.8.5:
   version "2.8.5"
@@ -4179,6 +4285,15 @@ cross-spawn@^7.0.0, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz"
   integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
+  dependencies:
+    path-key "^3.1.0"
+    shebang-command "^2.0.0"
+    which "^2.0.1"
+
+cross-spawn@^7.0.5:
+  version "7.0.6"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.6.tgz#8a58fe78f00dcd70c370451759dfbfaf03e8ee9f"
+  integrity sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==
   dependencies:
     path-key "^3.1.0"
     shebang-command "^2.0.0"
@@ -4317,6 +4432,13 @@ debug@^3.2.6, debug@^3.2.7:
   dependencies:
     ms "^2.1.1"
 
+debug@^4.4.0, debug@^4.4.3:
+  version "4.4.3"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.3.tgz#c6ae432d9bd9662582fce08709b038c58e9e3d6a"
+  integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
+  dependencies:
+    ms "^2.1.3"
+
 decimal.js@^10.2.1:
   version "10.4.3"
   resolved "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz"
@@ -4369,7 +4491,7 @@ delegates@^1.0.0:
   resolved "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz"
   integrity sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==
 
-depd@2.0.0:
+depd@2.0.0, depd@^2.0.0, depd@~2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz"
   integrity sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==
@@ -4557,6 +4679,11 @@ emojis-list@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz"
   integrity sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==
+
+encodeurl@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-2.0.0.tgz#7b8ea898077d7e409d3ac45474ea38eaf0857a58"
+  integrity sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==
 
 encodeurl@~1.0.2:
   version "1.0.2"
@@ -4840,7 +4967,7 @@ escalade@^3.1.1:
   resolved "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz"
   integrity sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==
 
-escape-html@~1.0.3:
+escape-html@^1.0.3, escape-html@~1.0.3:
   version "1.0.3"
   resolved "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz"
   integrity sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==
@@ -5074,7 +5201,7 @@ esutils@^2.0.2:
   resolved "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
-etag@~1.8.1:
+etag@^1.8.1, etag@~1.8.1:
   version "1.8.1"
   resolved "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz"
   integrity sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==
@@ -5093,6 +5220,18 @@ events@^3.2.0:
   version "3.3.0"
   resolved "https://registry.npmjs.org/events/-/events-3.3.0.tgz"
   integrity sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==
+
+eventsource-parser@^3.0.0, eventsource-parser@^3.0.1:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/eventsource-parser/-/eventsource-parser-3.0.6.tgz#292e165e34cacbc936c3c92719ef326d4aeb4e90"
+  integrity sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==
+
+eventsource@^3.0.2:
+  version "3.0.7"
+  resolved "https://registry.yarnpkg.com/eventsource/-/eventsource-3.0.7.tgz#1157622e2f5377bb6aef2114372728ba0c156989"
+  integrity sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==
+  dependencies:
+    eventsource-parser "^3.0.1"
 
 execa@^5.0.0:
   version "5.1.1"
@@ -5113,6 +5252,13 @@ exponential-backoff@^3.1.1:
   version "3.1.1"
   resolved "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.1.tgz"
   integrity sha512-dX7e/LHVJ6W3DE1MHWi9S1EYzDESENfLrYohG2G++ovZrYOkm4Knwa0mc1cn84xJOR4KEU0WSchhLbd0UklbHw==
+
+express-rate-limit@^8.2.1:
+  version "8.3.2"
+  resolved "https://registry.yarnpkg.com/express-rate-limit/-/express-rate-limit-8.3.2.tgz#81bbdbf599b7889a5b3cc272ec115aff200011be"
+  integrity sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==
+  dependencies:
+    ip-address "10.1.0"
 
 express@^4.17.3, express@^4.18.1:
   version "4.18.2"
@@ -5150,6 +5296,40 @@ express@^4.17.3, express@^4.18.1:
     type-is "~1.6.18"
     utils-merge "1.0.1"
     vary "~1.1.2"
+
+express@^5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/express/-/express-5.2.1.tgz#8f21d15b6d327f92b4794ecf8cb08a72f956ac04"
+  integrity sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==
+  dependencies:
+    accepts "^2.0.0"
+    body-parser "^2.2.1"
+    content-disposition "^1.0.0"
+    content-type "^1.0.5"
+    cookie "^0.7.1"
+    cookie-signature "^1.2.1"
+    debug "^4.4.0"
+    depd "^2.0.0"
+    encodeurl "^2.0.0"
+    escape-html "^1.0.3"
+    etag "^1.8.1"
+    finalhandler "^2.1.0"
+    fresh "^2.0.0"
+    http-errors "^2.0.0"
+    merge-descriptors "^2.0.0"
+    mime-types "^3.0.0"
+    on-finished "^2.4.1"
+    once "^1.4.0"
+    parseurl "^1.3.3"
+    proxy-addr "^2.0.7"
+    qs "^6.14.0"
+    range-parser "^1.2.1"
+    router "^2.2.0"
+    send "^1.1.0"
+    serve-static "^2.2.0"
+    statuses "^2.0.1"
+    type-is "^2.0.1"
+    vary "^1.1.2"
 
 extend@^3.0.0:
   version "3.0.2"
@@ -5190,6 +5370,11 @@ fast-levenshtein@^2.0.6:
   version "2.0.6"
   resolved "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz"
   integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
+
+fast-uri@^3.0.1:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.0.tgz#66eecff6c764c0df9b762e62ca7edcfb53b4edfa"
+  integrity sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==
 
 fastq@^1.6.0:
   version "1.15.0"
@@ -5251,6 +5436,18 @@ finalhandler@1.2.0:
     parseurl "~1.3.3"
     statuses "2.0.1"
     unpipe "~1.0.0"
+
+finalhandler@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/finalhandler/-/finalhandler-2.1.1.tgz#a2c517a6559852bcdb06d1f8bd7f51b68fad8099"
+  integrity sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==
+  dependencies:
+    debug "^4.4.0"
+    encodeurl "^2.0.0"
+    escape-html "^1.0.3"
+    on-finished "^2.4.1"
+    parseurl "^1.3.3"
+    statuses "^2.0.1"
 
 find-cache-dir@^3.3.2:
   version "3.3.2"
@@ -5351,6 +5548,11 @@ fresh@0.5.2:
   version "0.5.2"
   resolved "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz"
   integrity sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==
+
+fresh@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/fresh/-/fresh-2.0.0.tgz#8dd7df6a1b3a1b3a5cf186c05a5dd267622635a4"
+  integrity sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==
 
 fs-extra@^10.0.0:
   version "10.1.0"
@@ -5457,7 +5659,7 @@ get-intrinsic@^1.0.2, get-intrinsic@^1.1.1, get-intrinsic@^1.1.3, get-intrinsic@
     has "^1.0.3"
     has-symbols "^1.0.3"
 
-get-intrinsic@^1.2.6:
+get-intrinsic@^1.2.5, get-intrinsic@^1.2.6, get-intrinsic@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.3.0.tgz#743f0e3b6964a93a5491ed1bffaae054d7f98d01"
   integrity sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==
@@ -5742,6 +5944,11 @@ hdr-histogram-percentiles-obj@^3.0.0:
   resolved "https://registry.npmjs.org/hdr-histogram-percentiles-obj/-/hdr-histogram-percentiles-obj-3.0.0.tgz"
   integrity sha512-7kIufnBqdsBGcSZLPJwqHT3yhk1QTsSlFsVD3kx5ixH/AlgBs9yM1q6DPhXZ8f8gtdqgh7N7/5btRLpQsS2gHw==
 
+hono@^4.11.4:
+  version "4.12.11"
+  resolved "https://registry.yarnpkg.com/hono/-/hono-4.12.11.tgz#8acfea03c8fb5d8cb6e692186a119a0239a6b0df"
+  integrity sha512-r4xbIa3mGGGoH9nN4A14DOg2wx7y2oQyJEb5O57C/xzETG/qx4c7CVDQ5WMeKHZ7ORk2W0hZ/sQKXTav3cmYBA==
+
 hosted-git-info@^6.0.0:
   version "6.1.1"
   resolved "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-6.1.1.tgz"
@@ -5825,6 +6032,17 @@ http-errors@2.0.0:
     setprototypeof "1.2.0"
     statuses "2.0.1"
     toidentifier "1.0.1"
+
+http-errors@^2.0.0, http-errors@^2.0.1, http-errors@~2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-2.0.1.tgz#36d2f65bc909c8790018dd36fb4d93da6caae06b"
+  integrity sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==
+  dependencies:
+    depd "~2.0.0"
+    inherits "~2.0.4"
+    setprototypeof "~1.2.0"
+    statuses "~2.0.2"
+    toidentifier "~1.0.1"
 
 http-errors@~1.6.2:
   version "1.6.3"
@@ -5913,6 +6131,13 @@ iconv-lite@^0.6.2, iconv-lite@^0.6.3:
   dependencies:
     safer-buffer ">= 2.1.2 < 3.0.0"
 
+iconv-lite@^0.7.0, iconv-lite@~0.7.0:
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.7.2.tgz#d0bdeac3f12b4835b7359c2ad89c422a4d1cc72e"
+  integrity sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3.0.0"
+
 icss-utils@^5.0.0, icss-utils@^5.1.0:
   version "5.1.0"
   resolved "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz"
@@ -5976,7 +6201,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@2.0.4, inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.3:
+inherits@2, inherits@2.0.4, inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.3, inherits@~2.0.4:
   version "2.0.4"
   resolved "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -6027,6 +6252,11 @@ internal-slot@^1.0.3, internal-slot@^1.0.5:
     get-intrinsic "^1.2.0"
     has "^1.0.3"
     side-channel "^1.0.4"
+
+ip-address@10.1.0:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/ip-address/-/ip-address-10.1.0.tgz#d8dcffb34d0e02eb241427444a6e23f5b0595aa4"
+  integrity sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==
 
 ip-address@^9.0.5:
   version "9.0.5"
@@ -6188,6 +6418,11 @@ is-potential-custom-element-name@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz"
   integrity sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==
+
+is-promise@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-4.0.0.tgz#42ff9f84206c1991d26debf520dd5c01042dd2f3"
+  integrity sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==
 
 is-reference@^1.2.1:
   version "1.2.1"
@@ -6369,6 +6604,11 @@ jiti@^1.18.2:
   resolved "https://registry.npmjs.org/jiti/-/jiti-1.21.0.tgz"
   integrity sha512-gFqAIbuKyyso/3G2qhiO2OM6shY6EPP/R0+mkDbyspxKazh8BXDC5FiFsUjlczgdNz/vfra0da2y+aHrusLG/Q==
 
+jose@^6.1.3:
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/jose/-/jose-6.2.2.tgz#d6b5279b89b3e88d531c202e3fbe351f39a44aac"
+  integrity sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==
+
 js-sdsl@^4.1.4:
   version "4.4.0"
   resolved "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.4.0.tgz"
@@ -6461,6 +6701,11 @@ json-schema-traverse@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz"
   integrity sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==
+
+json-schema-typed@^8.0.2:
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/json-schema-typed/-/json-schema-typed-8.0.2.tgz#e98ee7b1899ff4a184534d1f167c288c66bbeff4"
+  integrity sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==
 
 json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"
@@ -6922,6 +7167,11 @@ media-typer@0.3.0:
   resolved "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
   integrity sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==
 
+media-typer@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-1.1.0.tgz#6ab74b8f2d3320f2064b2a87a38e7931ff3a5561"
+  integrity sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==
+
 memfs@^3.4.12, memfs@^3.4.3:
   version "3.4.13"
   resolved "https://registry.npmjs.org/memfs/-/memfs-3.4.13.tgz"
@@ -6933,6 +7183,11 @@ merge-descriptors@1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz"
   integrity sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w==
+
+merge-descriptors@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-2.0.0.tgz#ea922f660635a2249ee565e0449f951e6b603808"
+  integrity sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==
 
 merge-stream@^2.0.0:
   version "2.0.0"
@@ -6962,12 +7217,24 @@ mime-db@1.52.0, "mime-db@>= 1.43.0 < 2":
   resolved "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz"
   integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
 
+mime-db@^1.54.0:
+  version "1.54.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.54.0.tgz#cddb3ee4f9c64530dff640236661d42cb6a314f5"
+  integrity sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==
+
 mime-types@^2.1.27, mime-types@^2.1.31, mime-types@^2.1.35, mime-types@~2.1.17, mime-types@~2.1.24, mime-types@~2.1.34:
   version "2.1.35"
   resolved "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz"
   integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
   dependencies:
     mime-db "1.52.0"
+
+mime-types@^3.0.0, mime-types@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-3.0.2.tgz#39002d4182575d5af036ffa118100f2524b2e2ab"
+  integrity sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==
+  dependencies:
+    mime-db "^1.54.0"
 
 mime@1.6.0, mime@^1.4.1:
   version "1.6.0"
@@ -7163,7 +7430,7 @@ ms@2.1.2:
   resolved "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
-ms@2.1.3, ms@^2.0.0, ms@^2.1.1:
+ms@2.1.3, ms@^2.0.0, ms@^2.1.1, ms@^2.1.3:
   version "2.1.3"
   resolved "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
@@ -7230,6 +7497,11 @@ negotiator@0.6.3, negotiator@^0.6.3:
   version "0.6.3"
   resolved "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz"
   integrity sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==
+
+negotiator@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-1.0.0.tgz#b6c91bb47172d69f93cfd7c357bbb529019b5f6a"
+  integrity sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==
 
 neo-async@^2.6.2:
   version "2.6.2"
@@ -7458,6 +7730,11 @@ object-inspect@^1.12.3, object-inspect@^1.9.0:
   resolved "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz"
   integrity sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==
 
+object-inspect@^1.13.3:
+  version "1.13.4"
+  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.13.4.tgz#8375265e21bc20d0fa582c22e1b13485d6e00213"
+  integrity sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==
+
 object-keys@^1.1.1:
   version "1.1.1"
   resolved "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz"
@@ -7518,7 +7795,7 @@ obuf@^1.0.0, obuf@^1.1.2:
   resolved "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz"
   integrity sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==
 
-on-finished@2.4.1:
+on-finished@2.4.1, on-finished@^2.4.1:
   version "2.4.1"
   resolved "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz"
   integrity sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==
@@ -7537,7 +7814,7 @@ on-headers@~1.0.2:
   resolved "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz"
   integrity sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==
 
-once@^1.3.0:
+once@^1.3.0, once@^1.4.0:
   version "1.4.0"
   resolved "https://registry.npmjs.org/once/-/once-1.4.0.tgz"
   integrity sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==
@@ -7763,7 +8040,7 @@ parse5@^7.0.0:
   dependencies:
     entities "^4.4.0"
 
-parseurl@~1.3.2, parseurl@~1.3.3:
+parseurl@^1.3.3, parseurl@~1.3.2, parseurl@~1.3.3:
   version "1.3.3"
   resolved "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz"
   integrity sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==
@@ -7806,6 +8083,11 @@ path-to-regexp@0.1.7:
   resolved "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz"
   integrity sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==
 
+path-to-regexp@^8.0.0:
+  version "8.4.2"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-8.4.2.tgz#795c420c4f7ca45c5b887366f622ee0c9852cccd"
+  integrity sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==
+
 path-type@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz"
@@ -7836,6 +8118,11 @@ piscina@4.0.0, piscina@^4.0.0:
     hdr-histogram-percentiles-obj "^3.0.0"
   optionalDependencies:
     nice-napi "^1.0.2"
+
+pkce-challenge@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/pkce-challenge/-/pkce-challenge-5.0.1.tgz#3b4446865b17b1745e9ace2016a31f48ddf6230d"
+  integrity sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==
 
 pkg-dir@^4.1.0:
   version "4.2.0"
@@ -8023,7 +8310,7 @@ prop-types@^15.8.1:
     object-assign "^4.1.1"
     react-is "^16.13.1"
 
-proxy-addr@~2.0.7:
+proxy-addr@^2.0.7, proxy-addr@~2.0.7:
   version "2.0.7"
   resolved "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz"
   integrity sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==
@@ -8057,6 +8344,13 @@ qs@6.11.0:
   integrity sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==
   dependencies:
     side-channel "^1.0.4"
+
+qs@^6.14.0, qs@^6.14.1:
+  version "6.15.0"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.15.0.tgz#db8fd5d1b1d2d6b5b33adaf87429805f1909e7b3"
+  integrity sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==
+  dependencies:
+    side-channel "^1.1.0"
 
 querystringify@^2.1.1:
   version "2.2.0"
@@ -8099,6 +8393,16 @@ raw-body@2.5.2:
     http-errors "2.0.0"
     iconv-lite "0.4.24"
     unpipe "1.0.0"
+
+raw-body@^3.0.0, raw-body@^3.0.1:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-3.0.2.tgz#3e3ada5ae5568f9095d84376fd3a49b8fb000a51"
+  integrity sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==
+  dependencies:
+    bytes "~3.1.2"
+    http-errors "~2.0.1"
+    iconv-lite "~0.7.0"
+    unpipe "~1.0.0"
 
 react-dom@^18.2.0:
   version "18.2.0"
@@ -8377,6 +8681,17 @@ rollup@^3.0.0, rollup@^3.27.1:
   optionalDependencies:
     fsevents "~2.3.2"
 
+router@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/router/-/router-2.2.0.tgz#019be620b711c87641167cc79b99090f00b146ef"
+  integrity sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==
+  dependencies:
+    debug "^4.4.0"
+    depd "^2.0.0"
+    is-promise "^4.0.0"
+    parseurl "^1.3.3"
+    path-to-regexp "^8.0.0"
+
 run-async@^2.4.0:
   version "2.4.1"
   resolved "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz"
@@ -8557,6 +8872,23 @@ send@0.18.0:
     range-parser "~1.2.1"
     statuses "2.0.1"
 
+send@^1.1.0, send@^1.2.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/send/-/send-1.2.1.tgz#9eab743b874f3550f40a26867bf286ad60d3f3ed"
+  integrity sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==
+  dependencies:
+    debug "^4.4.3"
+    encodeurl "^2.0.0"
+    escape-html "^1.0.3"
+    etag "^1.8.1"
+    fresh "^2.0.0"
+    http-errors "^2.0.1"
+    mime-types "^3.0.2"
+    ms "^2.1.3"
+    on-finished "^2.4.1"
+    range-parser "^1.2.1"
+    statuses "^2.0.2"
+
 serialize-javascript@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz"
@@ -8594,6 +8926,16 @@ serve-static@1.15.0:
     parseurl "~1.3.3"
     send "0.18.0"
 
+serve-static@^2.2.0:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/serve-static/-/serve-static-2.2.1.tgz#7f186a4a4e5f5b663ad7a4294ff1bf37cf0e98a9"
+  integrity sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==
+  dependencies:
+    encodeurl "^2.0.0"
+    escape-html "^1.0.3"
+    parseurl "^1.3.3"
+    send "^1.2.0"
+
 set-blocking@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz"
@@ -8604,7 +8946,7 @@ setprototypeof@1.1.0:
   resolved "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz"
   integrity sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==
 
-setprototypeof@1.2.0:
+setprototypeof@1.2.0, setprototypeof@~1.2.0:
   version "1.2.0"
   resolved "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz"
   integrity sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==
@@ -8633,6 +8975,35 @@ shell-quote@^1.8.1:
   resolved "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.1.tgz"
   integrity sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA==
 
+side-channel-list@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/side-channel-list/-/side-channel-list-1.0.0.tgz#10cb5984263115d3b7a0e336591e290a830af8ad"
+  integrity sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==
+  dependencies:
+    es-errors "^1.3.0"
+    object-inspect "^1.13.3"
+
+side-channel-map@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/side-channel-map/-/side-channel-map-1.0.1.tgz#d6bb6b37902c6fef5174e5f533fab4c732a26f42"
+  integrity sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==
+  dependencies:
+    call-bound "^1.0.2"
+    es-errors "^1.3.0"
+    get-intrinsic "^1.2.5"
+    object-inspect "^1.13.3"
+
+side-channel-weakmap@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz#11dda19d5368e40ce9ec2bdc1fb0ecbc0790ecea"
+  integrity sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==
+  dependencies:
+    call-bound "^1.0.2"
+    es-errors "^1.3.0"
+    get-intrinsic "^1.2.5"
+    object-inspect "^1.13.3"
+    side-channel-map "^1.0.1"
+
 side-channel@^1.0.4:
   version "1.0.4"
   resolved "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz"
@@ -8641,6 +9012,17 @@ side-channel@^1.0.4:
     call-bind "^1.0.0"
     get-intrinsic "^1.0.2"
     object-inspect "^1.9.0"
+
+side-channel@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.1.0.tgz#c3fcff9c4da932784873335ec9765fa94ff66bc9"
+  integrity sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==
+  dependencies:
+    es-errors "^1.3.0"
+    object-inspect "^1.13.3"
+    side-channel-list "^1.0.0"
+    side-channel-map "^1.0.1"
+    side-channel-weakmap "^1.0.2"
 
 signal-exit@^3.0.2, signal-exit@^3.0.3, signal-exit@^3.0.7:
   version "3.0.7"
@@ -8860,6 +9242,11 @@ statuses@2.0.1:
   version "1.5.0"
   resolved "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz"
   integrity sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==
+
+statuses@^2.0.1, statuses@^2.0.2, statuses@~2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/statuses/-/statuses-2.0.2.tgz#8f75eecef765b5e1cfcdc080da59409ed424e382"
+  integrity sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==
 
 streamroller@^3.1.5:
   version "3.1.5"
@@ -9151,7 +9538,7 @@ to-regex-range@^5.0.1:
   dependencies:
     is-number "^7.0.0"
 
-toidentifier@1.0.1:
+toidentifier@1.0.1, toidentifier@~1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz"
   integrity sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==
@@ -9241,6 +9628,15 @@ type-fest@^0.21.3:
   resolved "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz"
   integrity sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==
 
+type-is@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/type-is/-/type-is-2.0.1.tgz#64f6cf03f92fce4015c2b224793f6bdd4b068c97"
+  integrity sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==
+  dependencies:
+    content-type "^1.0.5"
+    media-typer "^1.1.0"
+    mime-types "^3.0.0"
+
 type-is@~1.6.18:
   version "1.6.18"
   resolved "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz"
@@ -9268,6 +9664,11 @@ typescript@^4.7.3, typescript@~4.9.5:
   resolved "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz"
   integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
 
+typescript@^5.8.3:
+  version "5.9.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.9.3.tgz#5b4f59e15310ab17a216f5d6cf53ee476ede670f"
+  integrity sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==
+
 ua-parser-js@^0.7.30:
   version "0.7.34"
   resolved "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.34.tgz"
@@ -9282,6 +9683,11 @@ unbox-primitive@^1.0.2:
     has-bigints "^1.0.2"
     has-symbols "^1.0.3"
     which-boxed-primitive "^1.0.2"
+
+undici-types@~6.21.0:
+  version "6.21.0"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.21.0.tgz#691d00af3909be93a7faa13be61b3a5b50ef12cb"
+  integrity sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==
 
 unicode-canonical-property-names-ecmascript@^2.0.0:
   version "2.0.0"
@@ -9417,7 +9823,7 @@ validate-npm-package-name@^5.0.0:
   dependencies:
     builtins "^5.0.0"
 
-vary@^1, vary@~1.1.2:
+vary@^1, vary@^1.1.2, vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz"
   integrity sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==
@@ -9838,6 +10244,21 @@ yocto-queue@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.0.0.tgz"
   integrity sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==
+
+zod-to-json-schema@^3.25.1:
+  version "3.25.2"
+  resolved "https://registry.yarnpkg.com/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz#3fa799a7badd554541472fb65843fdc460b2e5aa"
+  integrity sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==
+
+zod@^3.24.4:
+  version "3.25.76"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-3.25.76.tgz#26841c3f6fd22a6a2760e7ccb719179768471e34"
+  integrity sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==
+
+"zod@^3.25 || ^4.0":
+  version "4.3.6"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-4.3.6.tgz#89c56e0aa7d2b05107d894412227087885ab112a"
+  integrity sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==
 
 zone.js@~0.13.3:
   version "0.13.3"


### PR DESCRIPTION
## Summary

Adds a new `@oneschema/mcp-server` package to the monorepo — a standalone [Model Context Protocol](https://modelcontextprotocol.io) server that wraps the OneSchema Multi FileFeed and flowgraph public API, enabling AI assistants (Claude, etc.) to create, export, and manage workflows via natural language.

**Architecture:** Uses the low-level MCP `Server` class with plain JSON Schema tool descriptors instead of the high-level `McpServer` class. This was necessary because `McpServer`'s deeply generic `.tool()` method causes TypeScript to OOM when registering 10+ tools with inline Zod schemas.

**Tools (10):** `list_workflows`, `get_workflow`, `export_flowgraph`, `create_workflow_from_flowgraph`, `create_simple_workflow`, `duplicate_workflow`, `update_workflow`, `delete_workflow`, `get_template`, `create_template`

**Resources (4):** `oneschema://node-types`, `oneschema://workflows`, `oneschema://workflows/{id}`, `oneschema://workflows/{id}/flowgraph`

**Prompts (2):** `create_simple_workflow`, `describe_workflow`

**Tests:** 25 integration tests using Node.js built-in test runner — mock HTTP server for tool dispatch tests + in-memory MCP client↔server transport for full protocol tests.

**Scripts:** `yarn inspect` launches the MCP Inspector for interactive local debugging.

### Updates since last revision

- **Fixed error response body handling** (`api-client.ts`): The Fetch response stream was being double-consumed — `res.json()` consumed the body, so the `res.text()` fallback silently returned `undefined` for non-JSON error responses (e.g. HTML error pages). Now reads the body as text first, then attempts `JSON.parse()`, preserving the raw text for non-JSON errors.

## Review & Testing Checklist for Human

- [ ] **Tool input JSON Schemas match actual API contract** — The schemas in `tools.ts` are hand-written JSON Schema objects (not derived from types). Verify the `create_workflow_from_flowgraph` nested flowgraph schema matches what `POST /v0/multi-file-feeds/import-from-json` actually expects, especially required fields and the node type enum.
- [ ] **No runtime input validation** — Tool arguments arrive as untyped `Record<string, unknown>` and are cast with `as`. Malformed input from AI clients will pass straight through to the API. Confirm this is acceptable, or whether adding Zod `.parse()` calls inside `handleToolCall` is needed.
- [ ] **`zod` is still listed as a direct dependency but is no longer imported** — After switching away from `McpServer`, no source file imports `zod`. It's a transitive dep of `@modelcontextprotocol/sdk` but the direct dep could be removed. Confirm whether to keep or remove.
- [ ] **`private: false`** — Package is marked publishable. Confirm this is intentional for a v0.1.0.
- [ ] **Test against the real local API** — Run `ONESCHEMA_API_KEY=<key> ONESCHEMA_API_URL=http://api.oneschema.me:9450 yarn test` to verify against an actual OneSchema instance. The mock server is a happy-path stub and doesn't validate request bodies or auth headers.

### Notes

- The `matchUriTemplate()` helper is duplicated in `index.ts` and `server.test.ts`. Could be extracted to a shared util in a follow-up.
- `server.test.ts` manually re-registers all MCP handlers (mirroring `index.ts`) rather than importing a shared setup function. A refactor to export the server wiring as a function would improve maintainability.
- `clone_and_modify_workflow` tool and `add_transform_step` prompt were intentionally excluded per discussion — they depend on an update transforms endpoint that is still in progress.

Link to Devin session: https://app.devin.ai/sessions/812327b247984f84bfcca86278906b35
Requested by: @matthewoey