### PR TITLE
feat: add user-activity event for iframe activity detection

### DIFF
--- a/packages/importer-react/src/OneSchemaImporter.tsx
+++ b/packages/importer-react/src/OneSchemaImporter.tsx
@@ -66,6 +66,13 @@ export interface OneSchemaImporterBaseProps {
    * Or when launching fails, based on result
    */
   onLaunched?: (result: OneSchemaLaunchStatus) => void
+
+  /**
+   * Handler for when user activity is detected inside the importer iframe.
+   * Useful for resetting session idle timers in the host application.
+   * This event is throttled (fired at most once every 30 seconds).
+   */
+  onUserActivity?: () => void
 }
 
 /**
@@ -88,6 +95,7 @@ export default function OneSchemaImporter({
   onError,
   onPageLoad,
   onLaunched,
+  onUserActivity,
   ...params
 }: OneSchemaImporterProps) {
   const [importer] = useState(() => {
@@ -133,12 +141,16 @@ export default function OneSchemaImporter({
       importer.on("launched", (data: OneSchemaLaunchStatus) => {
         onLaunched?.(data)
       })
+
+      importer.on("user-activity", () => {
+        onUserActivity?.()
+      })
     }
 
     return () => {
       importer?.removeAllListeners()
     }
-  }, [importer, onSuccess, onCancel, onError, onRequestClose, onLaunched, onPageLoad])
+  }, [importer, onSuccess, onCancel, onError, onRequestClose, onLaunched, onPageLoad, onUserActivity])
 
   useEffect(() => {
     if (className) {

--- a/packages/importer/src/importer.ts
+++ b/packages/importer/src/importer.ts
@@ -502,6 +502,11 @@ export class OneSchemaImporterClass extends EventEmitter {
         }
         return
       }
+
+      case "user-activity": {
+        this.emit("user-activity")
+        return
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

Adds SDK support for a new `user-activity` event emitted by the importer iframe when user interaction is detected (mousemove, keydown, click, scroll, touchstart). This enables host applications to detect activity within the cross-origin OneSchema iframe and reset their session idle timers (e.g. `react-idle-timer`). `user-activity` events will be emitted at most once every thirty seconds. After a `user-activity` event is emitted, there is a thirty second timeout so events will not be emitted in rapid succession. 

**Changes:**
- **`packages/importer/src/importer.ts`**: Handle incoming `"user-activity"` postMessage from the iframe and re-emit it as a SDK event
- **`packages/importer-react/src/OneSchemaImporter.tsx`**: Add `onUserActivity` callback prop that subscribes to the new event

**Usage:**
```tsx
// Vanilla JS
importer.on('user-activity', () => idleTimer.reset())

// React
<OneSchemaImporter onUserActivity={() => idleTimer.reset()} />
```
