### PR TITLE
fix: bump init retry count and version for 0.7.5/0.5.3 release

### DIFF
--- a/packages/filefeeds-react/package.json
+++ b/packages/filefeeds-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@oneschema/filefeeds-react",
   "private": false,
-  "version": "0.5.2",
+  "version": "0.6.0",
   "description": "React component for embedding OneSchema FileFeeds",
   "author": "OneSchema",
   "license": "MIT",
@@ -32,7 +32,7 @@
     "clean": "npx --yes rimraf dist"
   },
   "dependencies": {
-    "@oneschema/filefeeds": "^0.5.2",
+    "@oneschema/filefeeds": "^0.6.0",
     "tslib": "^2.4.0"
   },
   "devDependencies": {

--- a/packages/filefeeds-react/package.json
+++ b/packages/filefeeds-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@oneschema/filefeeds-react",
   "private": false,
-  "version": "0.6.0",
+  "version": "0.5.3",
   "description": "React component for embedding OneSchema FileFeeds",
   "author": "OneSchema",
   "license": "MIT",
@@ -32,7 +32,7 @@
     "clean": "npx --yes rimraf dist"
   },
   "dependencies": {
-    "@oneschema/filefeeds": "^0.6.0",
+    "@oneschema/filefeeds": "^0.5.3",
     "tslib": "^2.4.0"
   },
   "devDependencies": {

--- a/packages/filefeeds/package.json
+++ b/packages/filefeeds/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@oneschema/filefeeds",
   "private": false,
-  "version": "0.5.2",
+  "version": "0.6.0",
   "description": "OneSchema FileFeeds embedding library",
   "author": "OneSchema",
   "license": "MIT",

--- a/packages/filefeeds/package.json
+++ b/packages/filefeeds/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@oneschema/filefeeds",
   "private": false,
-  "version": "0.6.0",
+  "version": "0.5.3",
   "description": "OneSchema FileFeeds embedding library",
   "author": "OneSchema",
   "license": "MIT",

--- a/packages/filefeeds/src/filefeeds.ts
+++ b/packages/filefeeds/src/filefeeds.ts
@@ -5,7 +5,7 @@ import { DEFAULT_PARAMS, FileFeedsLaunchParams, FileFeedsParams } from "./config
 import { FileFeedsEvent } from "./events"
 import { merged } from "./shared/utils"
 
-const LAUNCH_RETRY_MAX_COUNT = 20
+const LAUNCH_RETRY_MAX_COUNT = 40
 const LAUNCH_RETRY_DELAY_MS = 500
 
 const FILE_FEEDS_TRANSFORMS_EMBED_MARKER = "transforms.filefeeds.oneschema.co"

--- a/packages/filefeeds/src/filefeeds.ts
+++ b/packages/filefeeds/src/filefeeds.ts
@@ -5,7 +5,7 @@ import { DEFAULT_PARAMS, FileFeedsLaunchParams, FileFeedsParams } from "./config
 import { FileFeedsEvent } from "./events"
 import { merged } from "./shared/utils"
 
-const LAUNCH_RETRY_MAX_COUNT = 10
+const LAUNCH_RETRY_MAX_COUNT = 20
 const LAUNCH_RETRY_DELAY_MS = 500
 
 const FILE_FEEDS_TRANSFORMS_EMBED_MARKER = "transforms.filefeeds.oneschema.co"

--- a/packages/importer-angular/projects/oneschema/package.json
+++ b/packages/importer-angular/projects/oneschema/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@oneschema/angular",
   "private": false,
-  "version": "0.7.4",
+  "version": "0.8.0",
   "description": "Angular module for embedding OneSchema Importer",
   "author": "OneSchema",
   "license": "MIT",

--- a/packages/importer-angular/projects/oneschema/package.json
+++ b/packages/importer-angular/projects/oneschema/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@oneschema/angular",
   "private": false,
-  "version": "0.8.0",
+  "version": "0.7.5",
   "description": "Angular module for embedding OneSchema Importer",
   "author": "OneSchema",
   "license": "MIT",

--- a/packages/importer-react/package.json
+++ b/packages/importer-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@oneschema/react",
   "private": false,
-  "version": "0.7.4",
+  "version": "0.8.0",
   "description": "React component for embedding OneSchema Importer",
   "author": "OneSchema",
   "license": "MIT",

--- a/packages/importer-react/package.json
+++ b/packages/importer-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@oneschema/react",
   "private": false,
-  "version": "0.8.0",
+  "version": "0.7.5",
   "description": "React component for embedding OneSchema Importer",
   "author": "OneSchema",
   "license": "MIT",

--- a/packages/importer-vue/package.json
+++ b/packages/importer-vue/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@oneschema/vue",
   "private": false,
-  "version": "0.8.0",
+  "version": "0.7.5",
   "description": "Vue plugin for embedding OneSchema Importer",
   "author": "OneSchema",
   "license": "MIT",

--- a/packages/importer-vue/package.json
+++ b/packages/importer-vue/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@oneschema/vue",
   "private": false,
-  "version": "0.7.4",
+  "version": "0.8.0",
   "description": "Vue plugin for embedding OneSchema Importer",
   "author": "OneSchema",
   "license": "MIT",

--- a/packages/importer/package.json
+++ b/packages/importer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@oneschema/importer",
   "private": false,
-  "version": "0.8.0",
+  "version": "0.7.5",
   "description": "Vanilla JS library for embedding OneSchema Importer",
   "author": "OneSchema",
   "license": "MIT",

--- a/packages/importer/package.json
+++ b/packages/importer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@oneschema/importer",
   "private": false,
-  "version": "0.7.4",
+  "version": "0.8.0",
   "description": "Vanilla JS library for embedding OneSchema Importer",
   "author": "OneSchema",
   "license": "MIT",

--- a/packages/importer/src/importer.ts
+++ b/packages/importer/src/importer.ts
@@ -17,7 +17,7 @@ import {
 } from "./config"
 import { merged } from "./shared/utils"
 
-const MAX_LAUNCH_RETRY = 20
+const MAX_LAUNCH_RETRY = 40
 
 const IMPORTER_EMBED_MARKER = "importer.oneschema.co"
 

--- a/packages/importer/src/importer.ts
+++ b/packages/importer/src/importer.ts
@@ -17,7 +17,7 @@ import {
 } from "./config"
 import { merged } from "./shared/utils"
 
-const MAX_LAUNCH_RETRY = 10
+const MAX_LAUNCH_RETRY = 20
 
 const IMPORTER_EMBED_MARKER = "importer.oneschema.co"
 


### PR DESCRIPTION
## Summary

Increases the init retry window from ~5s to ~20s to reduce intermittent "OneSchema failed to respond for initialization" errors caused by slow iframe hydration on customer pages.

- `MAX_LAUNCH_RETRY` (importer): 10 → 40 (40 × 500ms = 20s)
- `LAUNCH_RETRY_MAX_COUNT` (filefeeds): 10 → 40

Bumps versions for release:
- Importer packages (`@oneschema/importer`, `@oneschema/react`, `@oneschema/vue`, `@oneschema/angular`): `0.7.4` → `0.7.5`
- FileFeeds packages (`@oneschema/filefeeds`, `@oneschema/filefeeds-react`): `0.5.2` → `0.5.3`

Requested by: @hkardos